### PR TITLE
26 27 networkoptions and plugins install

### DIFF
--- a/lib/service/Broker.js
+++ b/lib/service/Broker.js
@@ -66,7 +66,7 @@ Broker.prototype.initiateServer = function () {
           }
           fs.unlinkSync(this.config.socket);
           broker.close(() => {
-            server.listen(this.config.socket, initCB);
+            server.listen(this.config.socket);
           });
         });
     });

--- a/lib/service/Broker.js
+++ b/lib/service/Broker.js
@@ -65,9 +65,13 @@ Broker.prototype.initiateServer = function () {
             throw e;
           }
           fs.unlinkSync(this.config.socket);
-          broker.close(() => {
+          if (broker) {
+            broker.close(() => {
+              server.listen(this.config.socket);
+            });
+          } else {
             server.listen(this.config.socket);
-          });
+          }
         });
     });
     server.listen(this.config.socket, initCB);

--- a/test/service/broker.test.js
+++ b/test/service/broker.test.js
@@ -1,4 +1,5 @@
-// This a test file template
+'use strict';
+
 var
   should = require('should'),
   sinon = require('sinon'),
@@ -36,7 +37,7 @@ describe('Test: service/Broker', function () {
 
     serverMock = {
       on: sinon.spy(),
-      listen: sinon.stub().yields()
+      listen: sinon.stub()
     };
 
     sendRawSpy = sandbox.spy(function (dummy, callback) {
@@ -122,6 +123,9 @@ describe('Test: service/Broker', function () {
         .be.calledOnce()
         .be.calledWith(broker.config.port);
 
+      let initCB = serverMock.listen.firstCall.args[1];
+      initCB();
+
       should(webSocketConstructorSpy)
         .be.calledOnce();
     });
@@ -194,6 +198,7 @@ describe('Test: service/Broker', function () {
 
       should(serverMock.listen)
         .be.calledOnce();
+      let initCB = serverMock.listen.firstCall.args[1];
 
       netErrorCB({code: 'ECONNREFUSED'});
 
@@ -201,11 +206,21 @@ describe('Test: service/Broker', function () {
         .be.calledOnce()
         .be.calledWith(broker.config.socket);
 
+      should(Broker.__get__('WebSocketServer'))
+        .have.callCount(0);
+
+      should(serverMock.listen)
+        .be.calledTwice();
+
+      initCB();
+
+      netErrorCB({code: 'ECONNREFUSED'});
+
       should(Broker.__get__('WebSocketServer').firstCall.returnValue.close)
         .be.calledOnce();
 
       should(serverMock.listen)
-        .be.calledTwice();
+        .be.calledThrice();
 
     });
   });


### PR DESCRIPTION
Bug fix: When calling [http.server.listen](https://nodejs.org/api/http.html#http_server_listen_handle_callback) multiple times, the server is re-opened but the previously registered callbacks are still registered.