### PR TITLE
Add support for HTTP OPTIONS requests

### DIFF
--- a/lib/service/HttpProxy.js
+++ b/lib/service/HttpProxy.js
@@ -40,6 +40,19 @@ HttpProxy.prototype.init = function (context, config) {
         room: 'httpRequest'
       };
 
+    if (request.method.toUpperCase() === 'OPTIONS') {
+      response.writeHead(200, {
+        'Content-Type': 'text/html;charset=UTF-8',
+        'Access-Control-Allow-Origin': this.accessControlAllowOrigin,
+        'Access-Control-Allow-Methods' : 'GET,POST,PUT,DELETE,OPTIONS',
+        'Access-Control-Allow-Headers': 'Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With'
+      });
+
+      response.end();
+
+      return;
+    }
+
     if (request.headers['content-length'] > this.maxRequestSize) {
       request.resume();
       return replyWithError(this.accessControlAllowOrigin, response, new SizeLimitError('Error: maximum HTTP request size exceeded'));
@@ -84,7 +97,8 @@ function sendRequest (context, allowOrigin, response, message) {
       response.writeHead(result.status, {
         'Content-Type': result.type,
         'Access-Control-Allow-Origin': allowOrigin,
-        'Access-Control-Allow-Headers': 'X-Requested-With'
+        'Access-Control-Allow-Methods' : 'GET,POST,PUT,DELETE,OPTIONS',
+        'Access-Control-Allow-Headers': 'Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With'
       });
 
       response.end(result.response);
@@ -106,7 +120,8 @@ function replyWithError(allowOrigin, response, error) {
   response.writeHead(error.status, {
     'Content-Type': 'application/json',
     'Access-Control-Allow-Origin': allowOrigin,
-    'Access-Control-Allow-Headers': 'X-Requested-With'
+    'Access-Control-Allow-Methods' : 'GET,POST,PUT,DELETE,OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With'
   });
 
   response.end(JSON.stringify(error));

--- a/test/service/httpProxy.test.js
+++ b/test/service/httpProxy.test.js
@@ -119,7 +119,8 @@ describe('Test: service/HttpProxy', function () {
       should(responseStub.writeHead.calledWithMatch(1234, {
         'Content-Type': 'type',
         'Access-Control-Allow-Origin': '*',
-        'Access-Control-Allow-Headers': 'X-Requested-With'
+        'Access-Control-Allow-Methods' : 'GET,POST,PUT,DELETE,OPTIONS',
+        'Access-Control-Allow-Headers': 'Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With'
       })).be.true();
 
       should(responseStub.end.calledWith('response')).be.true();
@@ -140,7 +141,8 @@ describe('Test: service/HttpProxy', function () {
       should(responseStub.writeHead.calledWithMatch(error.status, {
         'Content-Type': 'application/json',
         'Access-Control-Allow-Origin': '*',
-        'Access-Control-Allow-Headers': 'X-Requested-With'
+        'Access-Control-Allow-Methods' : 'GET,POST,PUT,DELETE,OPTIONS',
+        'Access-Control-Allow-Headers': 'Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With'
       })).be.true();
 
       should(responseStub.end.calledWith(JSON.stringify(error))).be.true();
@@ -153,7 +155,8 @@ describe('Test: service/HttpProxy', function () {
       should(responseStub.writeHead.calledWithMatch(413, {
         'Content-Type': 'application/json',
         'Access-Control-Allow-Origin': '*',
-        'Access-Control-Allow-Headers': 'X-Requested-With'
+        'Access-Control-Allow-Methods' : 'GET,POST,PUT,DELETE,OPTIONS',
+        'Access-Control-Allow-Headers': 'Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With'
       })).be.true();
 
       should(requestStub.resume.calledOnce).be.true();
@@ -182,7 +185,8 @@ describe('Test: service/HttpProxy', function () {
       should(responseStub.writeHead.calledWithMatch(1234, {
         'Content-Type': 'type',
         'Access-Control-Allow-Origin': '*',
-        'Access-Control-Allow-Headers': 'X-Requested-With'
+        'Access-Control-Allow-Methods' : 'GET,POST,PUT,DELETE,OPTIONS',
+        'Access-Control-Allow-Headers': 'Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With'
       })).be.true();
 
       should(responseStub.end.calledWith('response')).be.true();
@@ -215,11 +219,26 @@ describe('Test: service/HttpProxy', function () {
       should(responseStub.writeHead.calledWithMatch(413, {
         'Content-Type': 'application/json',
         'Access-Control-Allow-Origin': '*',
-        'Access-Control-Allow-Headers': 'X-Requested-With'
+        'Access-Control-Allow-Methods' : 'GET,POST,PUT,DELETE,OPTIONS',
+        'Access-Control-Allow-Headers': 'Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With'
       })).be.true();
 
       should(responseStub.end.firstCall.args[0]).startWith('{"status":413,"message":"Error: maximum HTTP request size exceeded","stack":');
 
+    });
+
+    it('should respond immediately when receiving an OPTIONS request', () => {
+      requestStub.method = 'OPTIONS';
+      messageHandler(requestStub, responseStub);
+
+      should(responseStub.writeHead.calledWithMatch(200, {
+        'Content-Type': 'text/html;charset=UTF-8',
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Methods' : 'GET,POST,PUT,DELETE,OPTIONS',
+        'Access-Control-Allow-Headers': 'Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With'
+      })).be.true();
+
+      should(responseStub.end.firstCall.args.length).be.eql(0);
     });
   });
 });


### PR DESCRIPTION
Allow clients to perform HTTP OPTIONS requests, for instance as a preflight request for subsequent AJAX calls.