### PR TITLE
fixes #37 - Add support for http headers

### DIFF
--- a/lib/service/HttpProxy.js
+++ b/lib/service/HttpProxy.js
@@ -107,11 +107,19 @@ function sendRequest (context, allowOrigin, response, payload) {
 
       let backendResponse;
       try {
+        let headerAdded = false;
+
         backendResponse = JSON.parse(result.response);
         Object.keys(backendResponse.headers)
           .forEach(header => {
             response.setHeader(header, backendResponse.headers[header]);
+            headerAdded = true;
           });
+
+        if (headerAdded) {
+          delete backendResponse.headers;
+          result.response = JSON.stringify(backendResponse);
+        }
       }
       catch (e) {
         // do nothing

--- a/lib/service/HttpProxy.js
+++ b/lib/service/HttpProxy.js
@@ -94,18 +94,30 @@ HttpProxy.prototype.init = function (context, config) {
  *
  * @param {Context} context
  * @param {string} allowOrigin - CORS header value
- * @param {Object} response
+ * @param {http.ServerResponse} response
  * @param {Object} payload
  */
 function sendRequest (context, allowOrigin, response, payload) {
   context.broker.brokerCallback(KuzzleRoom, payload.requestId, payload, (error, result) => {
     if (result) {
-      response.writeHead(result.status, {
-        'Content-Type': result.type,
-        'Access-Control-Allow-Origin': allowOrigin,
-        'Access-Control-Allow-Methods' : 'GET,POST,PUT,DELETE,OPTIONS',
-        'Access-Control-Allow-Headers': 'Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With'
-      });
+      response.setHeader('Content-Type', result.type);
+      response.setHeader('Access-Control-Allow-Origin', allowOrigin);
+      response.setHeader('Access-Control-Allow-Methods', 'GET,POST,PUT,DELETE,OPTIONS');
+      response.setHeader('Access-Control-Allow-Headers', 'Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With');
+
+      let backendResponse;
+      try {
+        backendResponse = JSON.parse(result.response);
+        Object.keys(backendResponse.headers)
+          .forEach(header => {
+            response.setHeader(header, backendResponse.headers[header]);
+          });
+      }
+      catch (e) {
+        // do nothing
+      }
+
+      response.writeHead(result.status);
 
       response.end(result.response);
     }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "bytes": "^2.4.0",
     "cli-color": "^1.1.0",
     "compare-versions": "^3.0.0",
-    "kuzzle-common-objects": "2.0.0",
+    "kuzzle-common-objects": "2.0.1",
     "lodash": "^4.14.1",
     "uuid": "3.0.0",
     "proper-lockfile": "^2.0.0",


### PR DESCRIPTION
:warning: needs https://github.com/kuzzleio/kuzzle-common-objects/pull/11 to be merged first.
fixes #37

This PR adds the ability to send some custom HTTP headers from Kuzzle (and most importantly, from a plugin).
The sad downside is that to do so, we have to JSON parse the response from Kuzzle :\