### PR TITLE
Response headers handling - remove double JSON stringification

### DIFF
--- a/lib/service/HttpProxy.js
+++ b/lib/service/HttpProxy.js
@@ -4,6 +4,7 @@ const
   http = require('http'),
   bytes = require('bytes'),
   uuid = require('uuid'),
+  url = require('url'),
   SizeLimitError = require('kuzzle-common-objects').errors.SizeLimitError,
   KuzzleRoom = 'httpRequest';
 
@@ -100,34 +101,34 @@ HttpProxy.prototype.init = function (context, config) {
 function sendRequest (context, allowOrigin, response, payload) {
   context.broker.brokerCallback(KuzzleRoom, payload.requestId, payload, (error, result) => {
     if (result) {
+      let indent = 0;
+      const parsedUrl = url.parse(payload.url, true);
+
+      if (parsedUrl.query && parsedUrl.query.pretty !== undefined) {
+        indent = 2;
+      }
+
       response.setHeader('Content-Type', result.type);
       response.setHeader('Access-Control-Allow-Origin', allowOrigin);
       response.setHeader('Access-Control-Allow-Methods', 'GET,POST,PUT,DELETE,OPTIONS');
       response.setHeader('Access-Control-Allow-Headers', 'Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With');
 
-      let backendResponse;
-      try {
-        let headerAdded = false;
-
-        backendResponse = JSON.parse(result.response);
-        Object.keys(backendResponse.headers)
+      if (result.response.headers) {
+        Object.keys(result.response.headers)
           .forEach(header => {
-            response.setHeader(header, backendResponse.headers[header]);
-            headerAdded = true;
+            response.setHeader(header, result.response.headers[header]);
           });
 
-        if (headerAdded) {
-          delete backendResponse.headers;
-          result.response = JSON.stringify(backendResponse);
-        }
-      }
-      catch (e) {
-        // do nothing
+        delete result.response.headers;
       }
 
       response.writeHead(result.status);
-
-      response.end(result.response);
+      if (typeof result.response === 'string' || result.response instanceof Buffer) {
+        response.end(result.response);
+      }
+      else {
+        response.end(JSON.stringify(result.response, undefined, indent));
+      }
     }
     else {
       replyWithError(allowOrigin, response, error);

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "bytes": "^2.4.0",
     "cli-color": "^1.1.0",
     "compare-versions": "^3.0.0",
-    "kuzzle-common-objects": "2.0.2",
+    "kuzzle-common-objects": "2.0.1",
     "lodash": "^4.14.1",
     "uuid": "3.0.0",
     "proper-lockfile": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "bytes": "^2.4.0",
     "cli-color": "^1.1.0",
     "compare-versions": "^3.0.0",
-    "kuzzle-common-objects": "2.0.1",
+    "kuzzle-common-objects": "2.0.2",
     "lodash": "^4.14.1",
     "uuid": "3.0.0",
     "proper-lockfile": "^2.0.0",

--- a/test/service/httpProxy.test.js
+++ b/test/service/httpProxy.test.js
@@ -102,12 +102,12 @@ describe('Test: service/HttpProxy', function () {
         brokerCallback: sinon.stub().yields(null, {
           status: 1234,
           type: 'type',
-          response: JSON.stringify({
+          response: {
             headers: {
               'X-Foo': 'bar'
             },
             result: 'result'
-          })
+          }
         })
       };
 
@@ -244,6 +244,26 @@ describe('Test: service/HttpProxy', function () {
       })).be.true();
 
       should(responseStub.end.firstCall.args.length).be.eql(0);
+    });
+
+    it('should prettify the output', () => {
+      context.broker = {
+        brokerCallback: sinon.stub().yields(null, {
+          status: 1234,
+          type: 'type',
+          response: {
+            foo: 'bar'
+          }
+        })
+      };
+
+      requestStub.url = 'url?pretty';
+      messageHandler(requestStub, responseStub);
+
+      requestStub.emit('end');
+
+      should(responseStub.end)
+        .be.calledWith(JSON.stringify({ foo: 'bar'}, undefined, 2));
     });
   });
 });


### PR DESCRIPTION
Following [previous merge of this branch](#38), @dbengsch noticed the JSON parsing could actually be removed by making Kuzzle send the response as an object.

:warning: both this pr and [its related one on Kuzzle](https://github.com/kuzzleio/kuzzle/pull/575) need to be merged at the same time.