### PR TITLE
Kuzzle #586: dynamic http options

### DIFF
--- a/.proxyrc.sample
+++ b/.proxyrc.sample
@@ -47,13 +47,9 @@
   //   maxRequestSize: the size limit of a request. If it's a string, the
   //       value is passed to the "bytes" library (https://www.npmjs.com/package/bytes).
   //       If this is a number, then the value specifies the number of bytes.
-  //   accessControlAllowOrigin: sets the Access-Control-Allow-Origin header used to
-  //       send responses to the client
-  //       (see https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS)
   //   [host]:  ip on which the proxy should bind itself for http connections. Defaults to all interfaces
   "http": {
     "port": 7511,
-    "maxRequestSize": "1MB",
-    "accessControlAllowOrigin": "*"
+    "maxRequestSize": "1MB"
   }
 }

--- a/.proxyrc.sample
+++ b/.proxyrc.sample
@@ -9,7 +9,7 @@
   //   config: the plugin configuration
   "protocolPlugins": {
     "kuzzle-plugin-websocket": {
-      "version": "1.0.6",
+      "version": "1.0.7",
       "activated": true,
       "config": {
         "port": 7513,
@@ -17,7 +17,7 @@
       }
     },
     "kuzzle-plugin-socketio": {
-      "version": "2.0.2",
+      "version": "2.0.3",
       "activated": true,
       "config": {
         "port": 7512,

--- a/lib/core/config.js
+++ b/lib/core/config.js
@@ -34,7 +34,7 @@ function unstringify (cfg) {
 config = rc('proxy', {
   protocolPlugins: {
     'kuzzle-plugin-websocket': {
-      version: '1.0.6',
+      version: '1.0.7',
       activated: true,
       config: {
         port: 7513,
@@ -42,7 +42,7 @@ config = rc('proxy', {
       }
     },
     'kuzzle-plugin-socketio': {
-      version: '2.0.2',
+      version: '2.0.3',
       activated: true,
       config: {
         port: 7512,

--- a/lib/core/config.js
+++ b/lib/core/config.js
@@ -57,8 +57,7 @@ config = rc('proxy', {
   },
   http: {
     port: 7511,
-    maxRequestSize: '1MB',
-    accessControlAllowOrigin: '*'
+    maxRequestSize: '1MB'
   }
 });
 

--- a/lib/service/HttpProxy.js
+++ b/lib/service/HttpProxy.js
@@ -92,15 +92,22 @@ function sendRequest (context, response, payload) {
         indent = 2;
       }
 
-      Object.keys(result.response.headers)
-        .forEach(header => {
-          response.setHeader(header, result.response.headers[header]);
-        });
+      if (result.response.headers) {
+        Object.keys(result.response.headers)
+          .forEach(header => {
+            response.setHeader(header, result.response.headers[header]);
+          });
+      }
 
       response.writeHead(result.status);
 
-      if (typeof result.response.content === 'string' || result.response instanceof Buffer) {
-        response.end(result.response.content);
+      if (result.response.raw || result.response instanceof Buffer) {
+        if (typeof result.response.content === 'object') {
+          response.end(JSON.stringify(result.response.content));
+        }
+        else {
+          response.end(Buffer.from(result.response.content));
+        }
       }
       else {
         response.end(JSON.stringify(result.response.content, undefined, indent));

--- a/lib/service/HttpProxy.js
+++ b/lib/service/HttpProxy.js
@@ -14,7 +14,6 @@ const
  */
 function HttpProxy () {
   this.maxRequestSize = null;
-  this.accessControlAllowOrigin = null;
   this.server = null;
   return this;
 }
@@ -27,7 +26,6 @@ function HttpProxy () {
  */
 HttpProxy.prototype.init = function (context, config) {
   this.maxRequestSize = bytes.parse(config.http.maxRequestSize);
-  this.accessControlAllowOrigin = config.http.accessControlAllowOrigin;
 
   if (this.maxRequestSize === null || isNaN(this.maxRequestSize)) {
     throw new Error('Invalid HTTP "maxRequestSize" parameter');
@@ -47,22 +45,9 @@ HttpProxy.prototype.init = function (context, config) {
         content: ''
       };
 
-    if (request.method.toUpperCase() === 'OPTIONS') {
-      response.writeHead(200, {
-        'Content-Type': 'text/html;charset=UTF-8',
-        'Access-Control-Allow-Origin': this.accessControlAllowOrigin,
-        'Access-Control-Allow-Methods' : 'GET,POST,PUT,DELETE,OPTIONS',
-        'Access-Control-Allow-Headers': 'Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With'
-      });
-
-      response.end();
-
-      return;
-    }
-
     if (request.headers['content-length'] > this.maxRequestSize) {
       request.resume();
-      return replyWithError(this.accessControlAllowOrigin, response, new SizeLimitError('Error: maximum HTTP request size exceeded'));
+      return replyWithError(response, new SizeLimitError('Error: maximum HTTP request size exceeded'));
     }
 
     request.on('data', chunk => {
@@ -78,12 +63,12 @@ HttpProxy.prototype.init = function (context, config) {
           .removeAllListeners('data')
           .removeAllListeners('end')
           .resume();
-        return replyWithError(this.accessControlAllowOrigin, response, new SizeLimitError('Error: maximum HTTP request size exceeded'));
+        return replyWithError(response, new SizeLimitError('Error: maximum HTTP request size exceeded'));
       }
     });
 
     request.on('end', () => {
-      sendRequest(context, this.accessControlAllowOrigin, response, payload);
+      sendRequest(context, response, payload);
     });
   });
 
@@ -94,11 +79,10 @@ HttpProxy.prototype.init = function (context, config) {
  * Sends a request to Kuzzle and forwards the response back to the client
  *
  * @param {Context} context
- * @param {string} allowOrigin - CORS header value
  * @param {http.ServerResponse} response
  * @param {Object} payload
  */
-function sendRequest (context, allowOrigin, response, payload) {
+function sendRequest (context, response, payload) {
   context.broker.brokerCallback(KuzzleRoom, payload.requestId, payload, (error, result) => {
     if (result) {
       let indent = 0;
@@ -108,11 +92,6 @@ function sendRequest (context, allowOrigin, response, payload) {
         indent = 2;
       }
 
-      response.setHeader('Content-Type', result.type);
-      response.setHeader('Access-Control-Allow-Origin', allowOrigin);
-      response.setHeader('Access-Control-Allow-Methods', 'GET,POST,PUT,DELETE,OPTIONS');
-      response.setHeader('Access-Control-Allow-Headers', 'Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With');
-
       if (result.response.headers) {
         Object.keys(result.response.headers)
           .forEach(header => {
@@ -121,8 +100,15 @@ function sendRequest (context, allowOrigin, response, payload) {
 
         delete result.response.headers;
       }
+      else {
+        response.setHeader('Content-Type', 'application/json');
+        response.setHeader('Access-Control-Allow-Origin', '*');
+        response.setHeader('Access-Control-Allow-Methods', 'GET,POST,PUT,DELETE,OPTIONS');
+        response.setHeader('Access-Control-Allow-Headers', 'Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With');
+      }
 
       response.writeHead(result.status);
+
       if (typeof result.response === 'string' || result.response instanceof Buffer) {
         response.end(result.response);
       }
@@ -131,7 +117,7 @@ function sendRequest (context, allowOrigin, response, payload) {
       }
     }
     else {
-      replyWithError(allowOrigin, response, error);
+      replyWithError(response, error);
     }
   });
 }
@@ -139,14 +125,13 @@ function sendRequest (context, allowOrigin, response, payload) {
 /**
  * Forward an error response to the client
  *
- * @param {string} allowOrigin - CORS header value
  * @param {Object} response
  * @param {Object} error
  */
-function replyWithError(allowOrigin, response, error) {
+function replyWithError(response, error) {
   response.writeHead(error.status, {
     'Content-Type': 'application/json',
-    'Access-Control-Allow-Origin': allowOrigin,
+    'Access-Control-Allow-Origin': '*',
     'Access-Control-Allow-Methods' : 'GET,POST,PUT,DELETE,OPTIONS',
     'Access-Control-Allow-Headers': 'Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With'
   });

--- a/lib/service/HttpProxy.js
+++ b/lib/service/HttpProxy.js
@@ -92,28 +92,18 @@ function sendRequest (context, response, payload) {
         indent = 2;
       }
 
-      if (result.response.headers) {
-        Object.keys(result.response.headers)
-          .forEach(header => {
-            response.setHeader(header, result.response.headers[header]);
-          });
-
-        delete result.response.headers;
-      }
-      else {
-        response.setHeader('Content-Type', 'application/json');
-        response.setHeader('Access-Control-Allow-Origin', '*');
-        response.setHeader('Access-Control-Allow-Methods', 'GET,POST,PUT,DELETE,OPTIONS');
-        response.setHeader('Access-Control-Allow-Headers', 'Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With');
-      }
+      Object.keys(result.response.headers)
+        .forEach(header => {
+          response.setHeader(header, result.response.headers[header]);
+        });
 
       response.writeHead(result.status);
 
-      if (typeof result.response === 'string' || result.response instanceof Buffer) {
-        response.end(result.response);
+      if (typeof result.response.content === 'string' || result.response instanceof Buffer) {
+        response.end(result.response.content);
       }
       else {
-        response.end(JSON.stringify(result.response, undefined, indent));
+        response.end(JSON.stringify(result.response.content, undefined, indent));
       }
     }
     else {

--- a/package.json
+++ b/package.json
@@ -27,13 +27,14 @@
     "bytes": "^2.4.0",
     "cli-color": "^1.1.0",
     "compare-versions": "^3.0.0",
+    "core-dump": "0.0.3",
     "kuzzle-common-objects": "2.0.1",
     "lodash": "^4.14.1",
-    "uuid": "3.0.0",
     "proper-lockfile": "^2.0.0",
     "proxyquire": "^1.7.10",
     "rc": "^1.1.6",
     "utf-8-validate": "^1.2.1",
+    "uuid": "3.0.0",
     "ws": "^1.1.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "bytes": "^2.4.0",
     "cli-color": "^1.1.0",
     "compare-versions": "^3.0.0",
-    "core-dump": "0.0.3",
     "kuzzle-common-objects": "2.1.0",
     "lodash": "^4.14.1",
     "proper-lockfile": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "cli-color": "^1.1.0",
     "compare-versions": "^3.0.0",
     "core-dump": "0.0.3",
-    "kuzzle-common-objects": "2.0.1",
+    "kuzzle-common-objects": "2.1.0",
     "lodash": "^4.14.1",
     "proper-lockfile": "^2.0.0",
     "proxyquire": "^1.7.10",

--- a/test/service/backend.test.js
+++ b/test/service/backend.test.js
@@ -85,7 +85,7 @@ describe('Test: service/Backend', function () {
 
       should(spyConsoleError)
         .be.calledOnce()
-        .be.calledWith('Bad message received from the backend : unexpected; Reason: SyntaxError: Unexpected token u');
+        .be.calledWithMatch('Bad message received from the backend : unexpected; Reason: SyntaxError: Unexpected token u');
     });
 
     it('message room "response" must call the promise resolution if message is ok', () => {

--- a/test/service/httpProxy.test.js
+++ b/test/service/httpProxy.test.js
@@ -117,10 +117,6 @@ describe('Test: service/HttpProxy', function () {
       should(context.broker.brokerCallback.calledWith('httpRequest', sinon.match.string, sinon.match(message), sinon.match.func)).be.true();
 
       should(responseStub.setHeader)
-        .be.calledWith('Content-Type', 'type')
-        .be.calledWith('Access-Control-Allow-Origin', '*')
-        .be.calledWith('Access-Control-Allow-Methods', 'GET,POST,PUT,DELETE,OPTIONS')
-        .be.calledWith('Access-Control-Allow-Headers', 'Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With')
         .be.calledWith('X-Foo', 'bar');
       should(responseStub.writeHead)
         .be.calledOnce()
@@ -230,20 +226,6 @@ describe('Test: service/HttpProxy', function () {
 
       should(responseStub.end.firstCall.args[0]).startWith('{"status":413,"message":"Error: maximum HTTP request size exceeded","stack":');
 
-    });
-
-    it('should respond immediately when receiving an OPTIONS request', () => {
-      requestStub.method = 'OPTIONS';
-      messageHandler(requestStub, responseStub);
-
-      should(responseStub.writeHead.calledWithMatch(200, {
-        'Content-Type': 'text/html;charset=UTF-8',
-        'Access-Control-Allow-Origin': '*',
-        'Access-Control-Allow-Methods' : 'GET,POST,PUT,DELETE,OPTIONS',
-        'Access-Control-Allow-Headers': 'Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With'
-      })).be.true();
-
-      should(responseStub.end.firstCall.args.length).be.eql(0);
     });
 
     it('should prettify the output', () => {


### PR DESCRIPTION
Requires:
* https://github.com/kuzzleio/kuzzle-common-objects/pull/13
* https://github.com/kuzzleio/kuzzle-plugin-socketio/pull/13
* https://github.com/kuzzleio/kuzzle-plugin-websocket/pull/11

Fix: https://github.com/kuzzleio/kuzzle/issues/586

## Changes

* The configuration property `accessControlAllowOrigin`, setting the HTTP `Access-Control-Allow-Origin` header, has been moved to the Kuzzle core project
* HTTP OPTIONS requests are no longer handled by the proxy. These are now forwarded to Kuzzle like any other request
* handle the new Kuzzle response format, including the raw response content for HTTP
