### PR TITLE
Access logs

### DIFF
--- a/lib/core/Context.js
+++ b/lib/core/Context.js
@@ -21,6 +21,7 @@ function Context (proxy) {
    Constructors exposed to plugins
    @namespace {Object} constructors
    @property {Request} Request - Constructor for Kuzzle Request objects
+   @property {ClientConnection} ClientConnection - Constructor for the Proxy client connection identifier
    */
   this.constructors = {
     ClientConnection,
@@ -50,6 +51,9 @@ function Context (proxy) {
     }
   });
 
+  /**
+   * @property log - Accessor to the proxy logger
+   */
   Object.defineProperty(this, 'log', {
     enumerable: true,
     get: function () {

--- a/lib/core/Context.js
+++ b/lib/core/Context.js
@@ -1,10 +1,12 @@
+'use strict';
+
 var
-  _ = require('lodash'),
-  ClientConnectionStore = require('../store/ClientConnection'),
-  PluginStore = require('../store/Plugin'),
+  ClientConnection = require('./clientConnection'),
   Request = require('kuzzle-common-objects').Request,
-  errors = require('kuzzle-common-objects').errors,
-  Router = require('../service/Router');
+  errors = require('kuzzle-common-objects').errors;
+
+let _proxy;
+
 
 /**
  * Context constructor
@@ -13,8 +15,8 @@ var
  * @param {String} backendMode
  * @constructor
  */
-function Context (BackendHandler, backendMode) {
-  var self = this; // used to allow property getters to access this context object
+function Context (proxy) {
+  _proxy = proxy;
 
   /**
    Constructors exposed to plugins
@@ -22,6 +24,7 @@ function Context (BackendHandler, backendMode) {
    @property {Request} Request - Constructor for Kuzzle Request objects
    */
   this.constructors = {
+    ClientConnection,
     Request
   };
 
@@ -29,12 +32,7 @@ function Context (BackendHandler, backendMode) {
    Kuzzle error objects
    @namespace {Object} errors
    */
-  this.errors = {};
-
-  // Injects error constructors in the "errors" object
-  _.forOwn(errors, (constructor, name) => {
-    this.errors[name] = constructor;
-  });
+  this.errors = errors;
 
   /**
    Accessors to instanciated objects
@@ -49,35 +47,10 @@ function Context (BackendHandler, backendMode) {
   Object.defineProperty(this.accessors, 'router', {
     enumerable: true,
     get: function () {
-      return self.router;
+      return _proxy.router;
     }
   });
-
-  /** @type {Broker} */
-  this.broker = null;
-
-  /** @type {ClientConnection} */
-  this.clientConnectionStore = new ClientConnectionStore();
-
-  /** @note Context is provided to the Handler to implement more complex handlers */
-  /** @type {ProxyBackendHandler} */
-  this.backendHandler = new BackendHandler(backendMode, this);
-
-  /** @type {Plugin} */
-  this.pluginStore = new PluginStore();
-
-  /** @type {Router} */
-  this.router = new Router(this);
 }
-
-/**
- * Dependency injection of the broker
- *
- * @param {Broker} broker
- */
-Context.prototype.setBroker = function (broker) {
-  this.broker = broker;
-};
 
 
 module.exports = Context;

--- a/lib/core/Context.js
+++ b/lib/core/Context.js
@@ -50,7 +50,13 @@ function Context (proxy) {
     }
   });
 
-  this.log = _proxy.log;
+  Object.defineProperty(this, 'log', {
+    enumerable: true,
+    get: function () {
+      return _proxy.log;
+    }
+  });
+
 }
 
 

--- a/lib/core/Context.js
+++ b/lib/core/Context.js
@@ -11,8 +11,7 @@ let _proxy;
 /**
  * Context constructor
  *
- * @param {ProxyBackendHandler} BackendHandler
- * @param {String} backendMode
+ * @param {KuzzleProxy} proxy
  * @constructor
  */
 function Context (proxy) {
@@ -50,6 +49,8 @@ function Context (proxy) {
       return _proxy.router;
     }
   });
+
+  this.log = _proxy.log;
 }
 
 

--- a/lib/core/KuzzleProxy.js
+++ b/lib/core/KuzzleProxy.js
@@ -144,7 +144,8 @@ class KuzzleProxy {
         switch (conf.transport || 'console') {
           case 'console':
             transports.push(new (winston.transports.Console)(Object.assign(opts, {
-              humanReadableUnhandledException: conf.humanReadableUnhandledException || true
+              humanReadableUnhandledException: conf.humanReadableUnhandledException || true,
+              stderrLevels: conf.stderrLevels || ['error', 'debug']
             })));
             break;
           case 'elasticsearch':
@@ -201,7 +202,7 @@ class KuzzleProxy {
    */
   logAccess (connectionId, request, error, result) {
     const
-      connection = this.clientConnectionStore.getByConnectionId(connectionId);
+      connection = this.clientConnectionStore.get(connectionId);
 
     if (!connection) {
       return this.log.warn(`[access log] No connection retrieved for connection id: ${connectionId}\n` +
@@ -263,7 +264,7 @@ class KuzzleProxy {
               }
             }
             catch (err) {
-              this.loggers.error.warn('Unable to extract user from authorization header: ' + connection.headers.authorization);
+              this.log.warn('Unable to extract user from authorization header: ' + connection.headers.authorization);
             }
           }
         }
@@ -307,7 +308,7 @@ class KuzzleProxy {
               user = JSON.parse(payload)._id;
             }
             catch (err) {
-              this.loggers.error.warn('Unable to extract user from jwt token: ' + request.data.jwt);
+              this.log.warn('Unable to extract user from jwt token: ' + request.data.jwt);
             }
           }
         }
@@ -318,7 +319,7 @@ class KuzzleProxy {
           user || '-',
           '[' + moment().format('DD/MMM/YYYY:HH:mm:ss ZZ') + ']',
           `"${verb} ${url} ${protocol}"`,
-          status,
+          status || '-',
           result ? Buffer.byteLength(result.raw ? result.content : JSON.stringify(result.content)) : '-',
           connection.headers.referer ? `"${connection.headers.referer}"` : '-',
           connection.headers['user-agent'] ? `"${connection.headers['user-agent']}"` : '-'

--- a/lib/core/KuzzleProxy.js
+++ b/lib/core/KuzzleProxy.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const
+let
   Broker = require('../service/Broker'),
   ClientConnectionStore = require('../store/ClientConnection'),
   Context = require('./Context'),
@@ -13,6 +13,7 @@ const
   WinstonElasticsearch = require('winston-elasticsearch'),
   WinstonSyslog = require('winston-syslog'),
   config = require('./config');
+
 
 /**
  * KuzzleProxy constructor
@@ -27,7 +28,7 @@ class KuzzleProxy {
 
     /** @type {Context} */
     this.context = new Context(this);
-    this.backendHandler = new BackendHandler(this.config.backend.mode, this.context);
+    this.backendHandler = new BackendHandler(this.config.backend.mode, this);
 
     /** @type {Broker} */
     this.broker = new Broker();
@@ -63,12 +64,17 @@ class KuzzleProxy {
   }
 
   start () {
+    this.initLogger();
+
     return this.installPluginsIfNeeded()
       .then(() => {
-        this.initLogger();
         this.initPlugins();
         this.broker.init(this, this.config.backend);
         this.httpProxy.init(this);
+      })
+      .catch(error => {
+        this.log.error(error);
+        throw error;
       });
   }
 
@@ -90,7 +96,7 @@ class KuzzleProxy {
    */
   initPlugins () {
     Object.keys(this.config.protocolPlugins).forEach(pluginName => {
-      var
+      let
         plugin,
         pluginDefinition = this.config.protocolPlugins[pluginName];
 
@@ -108,10 +114,6 @@ class KuzzleProxy {
         this.log.error(`Initialization of plugin ${pluginName} has failed; Reason: `, error.stack);
       }
     });
-
-    if (this.pluginStore.count() === 0) {
-      throw new Error('No plugin has been initialized properly. Shutting down.');
-    }
   }
 
   initLogger () {
@@ -135,7 +137,7 @@ class KuzzleProxy {
           showLevel: conf.showLevel || false
         };
 
-        switch (conf.type || 'console') {
+        switch (conf.transport || 'console') {
           case 'console':
             transports.push(new (winston.transports.Console)(Object.assign(opts, {
               humanReadableUnhandledException: conf.humanReadableUnhandledException || true
@@ -198,17 +200,19 @@ class KuzzleProxy {
       connection = this.clientConnectionStore.getByConnectionId(connectionId);
 
     if (!connection) {
-      return this.log.warn(`[access log] no connection retrieved for connection id: ${connectionId}\n` +
+      return this.log.warn(`[access log] No connection retrieved for connection id: ${connectionId}\n` +
         'Most likely, the connection was closed before the response we received.');
     }
 
     switch (this.config.logs.accessLogFormat) {
       case 'logstash': {
         // custom kuzzle logs to be exported to logstash
+        // @TODO: clean data to remove request & response content
         this.loggers.access.info({
           connection,
-          error: error,
-          result: result
+          request,
+          error,
+          result,
         });
         break;
       }
@@ -219,55 +223,57 @@ class KuzzleProxy {
           protocol = connection.protocol.toUpperCase(),
           url = '',
           user,
-          status = 200;
+          status;
 
         if (error) {
           url = '/error';
           if (error.status) {
             status = error.status;
           }
+          else {
+            status = 500;
+          }
         }
         else {
           status = result.status;
         }
 
-        // try to get plain user name, 1st form jwt token if present, then from basic auth
-        if (connection.headers.authorization) {
-          try {
-            if (/^Bearer /i.test(connection.headers.authorization)) {
-              const
-                b64Payload = connection.headers.authorization.replace(/^Bearer .*?\.(.*?)\..*$/i, '$1'),
-                payload = new Buffer(b64Payload, 'base64').toString('utf8');
-
-              user = JSON.parse(payload)._id;
-            }
-            else {
-              user = new Buffer(connection.headers.authorization, 'base64')
-                .toString('utf8')
-                .split(':')[0];
-            }
-          }
-          catch (err) {
-            this.loggers.error.warn('Unable to extract user from authorization header: ' + connection.headers.authorization);
-          }
-        }
-
-        if (connection && connection.protocol === 'http') {
+        if (connection && connection.protocol.startsWith('HTTP/')) {
           verb = request.method;
           url = request.url;
-          protocol += '/1.1';
+
+          // try to get plain user name, 1st form jwt token if present, then from basic auth
+          if (connection.headers.authorization) {
+            try {
+              if (/^Bearer /i.test(connection.headers.authorization)) {
+                const
+                  b64Payload = connection.headers.authorization.split('.')[1],
+                  payload = new Buffer(b64Payload, 'base64').toString('utf8');
+
+                user = JSON.parse(payload)._id;
+              }
+              else {
+                user = new Buffer(connection.headers.authorization, 'base64')
+                  .toString('utf8')
+                  .split(':')[0];
+              }
+            }
+            catch (err) {
+              this.loggers.error.warn('Unable to extract user from authorization header: ' + connection.headers.authorization);
+            }
+          }
         }
         else {
           // for other protocols than http, we reconstruct a pseudo url
           url = `/${request.data.controller}/${request.data.action}`;
           if (request.data.index) {
-            url += '/' + request.index;
+            url += '/' + request.data.index;
           }
           if (request.data.collection) {
-            url += '/' + request.collection;
+            url += '/' + request.data.collection;
           }
           if (request.data._id) {
-            url += '/' + request._id;
+            url += '/' + request.data._id;
           }
 
           const queryString = Object.keys(request.data)
@@ -288,16 +294,28 @@ class KuzzleProxy {
           if (queryString !== '') {
             url += '?' + queryString;
           }
+
+          if (request.data.jwt) {
+            try {
+              const
+                b64Paylod = request.data.jwt.split('.')[1],
+                payload = new Buffer(b64Paylod, 'base64').toString('utf8');
+              user = JSON.parse(payload)._id;
+            }
+            catch (err) {
+              this.loggers.error.warn('Unable to extract user from jwt token: ' + request.data.jwt);
+            }
+          }
         }
 
         this.loggers.access.info([
-          connection.ips.reverse()[this.config.logs.accessLogIpOffset],
+          connection.ips[connection.ips.length - 1 - this.config.logs.accessLogIpOffset],
           '-',
           user || '-',
           '[' + moment().format('DD/MMM/YYYY:HH:mm:ss ZZ') + ']',
           `"${verb} ${url} ${protocol}"`,
           status,
-          result ? Buffer.byteLength(JSON.stringify(result)) : '-',
+          result ? Buffer.byteLength(result.raw ? result.content : JSON.stringify(result.content)) : '-',
           connection.headers.referer ? `"${connection.headers.referer}"` : '-',
           connection.headers['user-agent'] ? `"${connection.headers['user-agent']}"` : '-'
         ].join(' '));

--- a/lib/core/KuzzleProxy.js
+++ b/lib/core/KuzzleProxy.js
@@ -212,12 +212,11 @@ class KuzzleProxy {
     switch (this.config.logs.accessLogFormat) {
       case 'logstash': {
         // custom kuzzle logs to be exported to logstash
-        // @TODO: clean data to remove request & response content
         this.loggers.access.info({
           connection,
           request,
-          error,
-          result,
+          error: error ? error.toString() : null,
+          status: error && error.status || result.status
         });
         break;
       }

--- a/lib/core/KuzzleProxy.js
+++ b/lib/core/KuzzleProxy.js
@@ -1,8 +1,16 @@
-var
+'use strict';
+
+const
   Broker = require('../service/Broker'),
+  ClientConnectionStore = require('../store/ClientConnection'),
   Context = require('./Context'),
   HttpProxy = require('../service/HttpProxy'),
+  moment = require('moment'),
   PluginPackage = require('../plugins/package'),
+  PluginStore = require('../store/Plugin'),
+  Router = require('../service/Router'),
+  winston = require('winston'),
+  WinstonElasticsearch = require('winston-elasticsearch'),
   config = require('./config');
 
 /**
@@ -10,84 +18,278 @@ var
  *
  * @param {ProxyBackendHandler} BackendHandler
  */
-function KuzzleProxy (BackendHandler) {
-  /** @type {Object} */
-  this.config = config;
+class KuzzleProxy {
+  constructor (BackendHandler) {
+    /** @type {Object} */
+    this.config = config;
 
-  /** @type {Context} */
-  this.context = new Context(BackendHandler, this.config.backend.mode);
 
-  /** @type {Broker} */
-  this.broker = new Broker();
+    /** @type {Context} */
+    this.context = new Context(this);
+    this.backendHandler = new BackendHandler(this.config.backend.mode, this.context);
 
-  /** @type {HttpProxy} */
-  this.httpProxy = new HttpProxy();
+    /** @type {Broker} */
+    this.broker = new Broker();
+
+    /** @type {HttpProxy} */
+    this.httpProxy = new HttpProxy();
+
+    /** @type {ClientConnection} */
+    this.clientConnectionStore = new ClientConnectionStore();
+
+    /** @type {Plugin} */
+    this.pluginStore = new PluginStore();
+
+    /** @type {Router} */
+    this.router = new Router(this);
+
+    this.loggers = {};
+  }
+
+  /**
+   *
+   * @type {{
+   *  silly: {Function},
+   *  debug: {Function} ,
+   *  verbose: {Function},
+   *  info: {Function},
+   *  warn: {Function},
+   *  error: {Function}
+   * }}
+   */
+  get log () {
+    return this.loggers.errors;
+  }
+
+  start () {
+    return this.installPluginsIfNeeded()
+      .then(() => {
+        this.initLogger();
+        this.initPlugins();
+        this.broker.init(this, this.config.backend);
+        this.httpProxy.init(this);
+      });
+  }
+
+  installPluginsIfNeeded () {
+    const promises = [];
+
+    Object.keys(this.config.protocolPlugins).forEach(pluginName => {
+      const pluginPackage = new PluginPackage(pluginName, this.config.protocolPlugins[pluginName]);
+      if (pluginPackage.needsInstall()) {
+        promises.push(pluginPackage.install());
+      }
+    });
+
+    return Promise.all(promises);
+  }
+
+  /**
+   * Reads configuration files and initializes plugins
+   */
+  initPlugins () {
+    Object.keys(this.config.protocolPlugins).forEach(pluginName => {
+      var
+        plugin,
+        pluginDefinition = this.config.protocolPlugins[pluginName];
+
+      if (!pluginDefinition.activated) {
+        return;
+      }
+
+      this.log.info(`Initializing protocol plugin ${pluginName}`);
+      try {
+        plugin = new (require(pluginName))();
+        plugin.init(pluginDefinition.config, this.context);
+
+        this.pluginStore.add(plugin);
+      } catch (error) {
+        this.log.error(`Initialization of plugin ${pluginName} has failed; Reason: `, error.stack);
+      }
+    });
+
+    if (this.pluginStore.count() === 0) {
+      throw new Error('No plugin has been initialized properly. Shutting down.');
+    }
+  }
+
+  initLogger () {
+
+    [
+      'access',
+      'errors'
+    ].forEach(type => {
+      this.config.logs[type].forEach(conf => {
+        const transports = [];
+
+        const opts = {
+          level: conf.level || 'info',
+          silent: conf.silent || false,
+          colorize: conf.colorize || false,
+          timestamp: conf.timestamp || false,
+          json: conf.json || false,
+          stringify: conf.stringify || false,
+          prettyPrint: conf.prettyPrint || false,
+          depth: conf.depth || false,
+          showLevel: conf.showLevel || false
+        };
+
+        switch (conf.type || 'console') {
+          case 'console':
+            transports.push(new (winston.transports.Console)(Object.assign(opts, {
+              humanReadableUnhandledException: conf.humanReadableUnhandledException || true
+            })));
+            break;
+          case 'elasticsearch':
+            transports.push(new WinstonElasticsearch(Object.assign(opts, {
+              index: conf.index,
+              indexPrefix: conf.indexPrefix || 'proxy',
+              indexSuffixPattern: conf.indexSuffixPattern || 'YYYY.MM',
+              messageType: conf.messageType || type,
+              ensureMappingTemplate: conf.ensureMappingTemplate !== false,
+              mappingTemplate: conf.mappingTemplate || `${type}.log.mapping.json`,
+              flushInterval: conf.flushInterval || 2000,
+              clientOpts: conf.clientOpts || {}
+
+            })));
+            break;
+          case 'file':
+            transports.push(new (winston.transports.File)(Object.assign(opts, {
+              filename: conf.filename || `proxy.${type}.log`,
+              maxSize: conf.maxSize,
+              maxFiles: conf.maxFiles,
+              eol: conf.eol || '\n',
+              logstash: conf.logstash || false,
+              tailable: conf.tailable,
+              maxRetries: conf.maxRetries || 2,
+              zippedArchive: conf.zippedArchive || false
+            })));
+            break;
+        }
+
+        this.loggers[type] = new (winston.Logger)({transports});
+      });
+
+    });
+  }
+
+  /**
+   * @param {string} connectionId
+   * @param {Error} error
+   * @param {RequestResponse} result
+   */
+  logAccess (connectionId, request, error, result) {
+    const
+      connection = this.clientConnectionStore.getByConnectionId(connectionId);
+
+    if (!connection) {
+      return this.log.warn(`[access log] no connection retrieved for connection id: ${connectionId}\n` +
+        'Most likely, the connection was closed before the response we received.');
+    }
+
+    switch (this.config.logs.accessLogFormat) {
+      case 'logstash': {
+        // custom kuzzle logs to be exported to logstash
+        this.loggers.access.info({
+          connection,
+          error: error,
+          result: result
+        });
+        break;
+      }
+      default: {
+        // = apache combined
+        let
+          verb = 'DO',
+          protocol = connection.protocol.toUpperCase(),
+          url = '',
+          user,
+          status = 200;
+
+        if (error) {
+          url = '/error';
+          if (error.status) {
+            status = error.status;
+          }
+        }
+        else {
+          status = result.status;
+        }
+
+        // try to get plain user name, 1st form jwt token if present, then from basic auth
+        if (connection.headers.authorization) {
+          try {
+            if (/^Bearer /i.test(connection.headers.authorization)) {
+              const
+                b64Payload = connection.headers.authorization.replace(/^Bearer .*?\.(.*?)\..*$/i, '$1'),
+                payload = new Buffer(b64Payload, 'base64').toString('utf8');
+
+              user = JSON.parse(payload)._id;
+            }
+            else {
+              user = new Buffer(connection.headers.authorization, 'base64')
+                .toString('utf8')
+                .split(':')[0];
+            }
+          }
+          catch (err) {
+            this.loggers.error.warn('Unable to extract user from authorization header: ' + connection.headers.authorization);
+          }
+        }
+
+        if (connection && connection.protocol === 'http') {
+          verb = request.method;
+          url = request.url;
+        }
+        else {
+          // for other protocols than http, we reconstruct a pseudo url
+          url = `/${request.data.controller}/${request.data.action}`;
+          if (request.data.index) {
+            url += '/' + request.index;
+          }
+          if (request.data.collection) {
+            url += '/' + request.collection;
+          }
+          if (request.data._id) {
+            url += '/' + request._id;
+          }
+
+          const queryString = Object.keys(request.data)
+            .filter(k => [
+              'timestamp',
+              'requestId',
+              'jwt',
+              'metadata',
+              'body',
+              'controller',
+              'action',
+              'index',
+              'collection',
+              '_id'
+            ].indexOf(k) < 0)
+            .map(k => k + '=' + request.data[k])
+            .join('&');
+          if (queryString !== '') {
+            url += '?' + queryString;
+          }
+        }
+
+        this.loggers.access.info([
+          connection.ips.reverse()[this.config.logs.accessLogIpOffset],
+          '-',
+          user || '-',
+          '[' + moment().format('DD/MMM/YYYY:HH:mm:ss ZZ') + ']',
+          `"${verb} ${url} ${protocol}"`,
+          status,
+          result ? Buffer.byteLength(JSON.stringify(result)) : '-',
+          connection.headers.referer ? `"${connection.headers.referer}"` : '-',
+          connection.headers['user-agent'] ? `"${connection.headers['user-agent']}"` : '-'
+        ].join(' '));
+      }
+    }
+  }
+
 }
 
-KuzzleProxy.prototype.start = function () {
-  return this.installPluginsIfNeeded()
-    .then(() => {
-      this.initPlugins();
-      this.initBroker();
-      this.initHttpProxy();
-    });
-};
-
-KuzzleProxy.prototype.installPluginsIfNeeded = function () {
-  var promises = [];
-
-  Object.keys(this.config.protocolPlugins).forEach(pluginName => {
-    var pluginPackage = new PluginPackage(pluginName, this.config.protocolPlugins[pluginName]);
-    if (pluginPackage.needsInstall()) {
-      promises.push(pluginPackage.install());
-    }
-  });
-
-  return Promise.all(promises);
-};
-
-/**
- * Reads configuration files and initializes plugins
- */
-KuzzleProxy.prototype.initPlugins = function () {
-  Object.keys(this.config.protocolPlugins).forEach(pluginName => {
-    var
-      plugin,
-      pluginDefinition = this.config.protocolPlugins[pluginName];
-
-    if (!pluginDefinition.activated) {
-      return;
-    }
-
-    console.log(`Initializing protocol plugin ${pluginName}`);
-    try {
-      plugin = new (require(pluginName))();
-      plugin.init(pluginDefinition.config, this.context);
-
-      this.context.pluginStore.add(plugin);
-    } catch (error) {
-      console.error(`Initialization of plugin ${pluginName} has failed; Reason: `, error);
-    }
-  });
-
-  if (this.context.pluginStore.count() === 0) {
-    throw new Error('No plugin has been initialized properly. Shutting down.');
-  }
-};
-
-/**
- * Intializes the broker
- */
-KuzzleProxy.prototype.initBroker = function () {
-  this.context.setBroker(this.broker);
-  this.broker.init(this.context, this.config.backend);
-};
-
-/**
- * Initializes the httpProxy
- */
-KuzzleProxy.prototype.initHttpProxy = function () {
-  this.httpProxy.init(this.context, this.config);
-};
 
 module.exports = KuzzleProxy;

--- a/lib/core/KuzzleProxy.js
+++ b/lib/core/KuzzleProxy.js
@@ -126,9 +126,9 @@ class KuzzleProxy {
       'access',
       'errors'
     ].forEach(type => {
-      this.config.logs[type].forEach(conf => {
-        const transports = [];
+      const transports = [];
 
+      this.config.logs[type].forEach(conf => {
         const opts = {
           level: conf.level || 'info',
           silent: conf.silent || false,
@@ -187,9 +187,9 @@ class KuzzleProxy {
             })));
           }
         }
-
-        this.loggers[type] = new (winston.Logger)({transports});
       });
+
+      this.loggers[type] = new (winston.Logger)({transports});
 
     });
   }

--- a/lib/core/KuzzleProxy.js
+++ b/lib/core/KuzzleProxy.js
@@ -45,7 +45,11 @@ class KuzzleProxy {
     /** @type {Router} */
     this.router = new Router(this);
 
-    this.loggers = {};
+    this.loggers = {
+      errors: {
+
+      }
+    };
   }
 
   /**

--- a/lib/core/KuzzleProxy.js
+++ b/lib/core/KuzzleProxy.js
@@ -11,6 +11,7 @@ const
   Router = require('../service/Router'),
   winston = require('winston'),
   WinstonElasticsearch = require('winston-elasticsearch'),
+  WinstonSyslog = require('winston-syslog'),
   config = require('./config');
 
 /**
@@ -150,7 +151,6 @@ class KuzzleProxy {
               mappingTemplate: conf.mappingTemplate || `${type}.log.mapping.json`,
               flushInterval: conf.flushInterval || 2000,
               clientOpts: conf.clientOpts || {}
-
             })));
             break;
           case 'file':
@@ -165,6 +165,20 @@ class KuzzleProxy {
               zippedArchive: conf.zippedArchive || false
             })));
             break;
+          case 'syslog': {
+            transports.push(new WinstonSyslog(Object.assign(opts, {
+              host: conf.host || 'localhost',
+              port: conf.port || 514,
+              protocol: conf.protocol || 'udp4',
+              path: conf.path || '/dev/log',
+              pid: conf.pid || process.pid,
+              facility: conf.facility || 'local0',
+              localhost: conf.localhost || 'localhost',
+              type: conf.type || 'BSD',
+              app_name: conf.app_name || process.title,
+              eol: conf.eol
+            })));
+          }
         }
 
         this.loggers[type] = new (winston.Logger)({transports});
@@ -175,8 +189,9 @@ class KuzzleProxy {
 
   /**
    * @param {string} connectionId
-   * @param {Error} error
-   * @param {RequestResponse} result
+   * @param {object} request - Custom format for HTTP, Request.serialize() output for other protocols
+   * @param {Error} error - Low level protocol error (NB: result can also contain an error)
+   * @param {RequestResponse} result - The response from Kuzzle
    */
   logAccess (connectionId, request, error, result) {
     const
@@ -240,6 +255,7 @@ class KuzzleProxy {
         if (connection && connection.protocol === 'http') {
           verb = request.method;
           url = request.url;
+          protocol += '/1.1';
         }
         else {
           // for other protocols than http, we reconstruct a pseudo url

--- a/lib/core/clientConnection.js
+++ b/lib/core/clientConnection.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const
+  uuid = require('uuid');
+
+class ClientConnection {
+
+  /**
+   * @constructor
+   * @param {string} protocol - The protocol used (http, websocket, socketio, mqtt etc)
+   * @param {Array.<string>} ips - The list of forwarded ips (= X-Forwarded-For http header + the final ip, i.e. client, proxy1, proxy2, etc.)
+   * @param {object} [headers] - Optional extra key-value object. I.e., for http, will receive the request headers
+   */
+  constructor (protocol, ips, headers) {
+    this.id = uuid.v4();
+    this.protocol = protocol;
+    this.headers = {};
+
+    if (!Array.isArray(ips)) {
+      throw new TypeError('Expected ips to be an Array, got ' + typeof ips);
+    }
+    this.ips = ips;
+
+    if (headers && typeof headers === 'object') {
+      this.headers = headers;
+    }
+  }
+
+}
+
+module.exports = ClientConnection;

--- a/lib/core/config.js
+++ b/lib/core/config.js
@@ -1,4 +1,4 @@
-var
+let
   config,
   rc = require('rc');
 
@@ -36,13 +36,15 @@ config = rc('proxy', {
     access: [
       {
         type: 'console',
-        level: 'info'
+        level: 'info',
+        stderrLevels: []
       }
     ],
     errors: [
       {
         type: 'console',
-        level: 'info'
+        level: 'info',
+        stderrLevels: ['warn', 'error', 'debug']
       }
     ],
     accessLogFormat: 'combined',

--- a/lib/core/config.js
+++ b/lib/core/config.js
@@ -32,6 +32,22 @@ function unstringify (cfg) {
 }
 
 config = rc('proxy', {
+  logs: {
+    access: [
+      {
+        type: 'console',
+        level: 'info'
+      }
+    ],
+    errors: [
+      {
+        type: 'console',
+        level: 'info'
+      }
+    ],
+    accessLogFormat: 'combined',
+    accessLogIpOffset: 0
+  },
   protocolPlugins: {
     'kuzzle-plugin-websocket': {
       version: '1.0.6',

--- a/lib/service/Backend.js
+++ b/lib/service/Backend.js
@@ -46,7 +46,7 @@ Backend.prototype.onMessage = function (payload) {
     message = JSON.parse(payload);
   }
   catch (error) {
-    return _proxy.log.error(`Bad message received from the backend : ${payload}; Reason: ${error}`);
+    return _proxy.log.error(`Bad message received from the backend: ${payload}; Reason: ${error}`);
   }
 
   if (!message.room) {
@@ -100,7 +100,7 @@ Backend.prototype.initializeMessageRooms = function () {
           _proxy.pluginStore.getByProtocol(client.protocol).notify(data);
         }
         catch (e) {
-          _proxy.log.error(`[Notify] Plugin ${client.protocol} failed: ${e.message}\nNotification data:\n`, util.inspect(data, {depth: null}));
+          _proxy.log.error(`[Notify] Plugin ${client.protocol} failed: ${e.message}\nNotification data:\n%s`, util.inspect(data, {depth: null}));
         }
       }
     },
@@ -110,7 +110,7 @@ Backend.prototype.initializeMessageRooms = function () {
           _proxy.pluginStore.plugins[plugin].broadcast(data);
         }
         catch (e) {
-          _proxy.log.error(`[Broadcast] Plugin ${_proxy.pluginStore.plugins[plugin].protocol} failed: ${e.message}\nNotification data:\n`, util.inspect(data, {depth: null}));
+          _proxy.log.error(`[Broadcast] Plugin ${_proxy.pluginStore.plugins[plugin].protocol} failed: ${e.message}\nNotification data:\n%s`, util.inspect(data, {depth: null}));
         }
       });
     }
@@ -135,7 +135,7 @@ Backend.prototype.onConnectionClose = function () {
  * @param {Error} error
  */
 Backend.prototype.onConnectionError = function(error) {
-  _proxy.log.error(`Connection error with backend ${this.socketIp}; Reason:`, error);
+  _proxy.log.error(`Connection error with backend ${this.socketIp}; Reason: ${error}`);
   _proxy.backendHandler.removeBackend(this);
   this.backendRequestStore.abortAll(new InternalError(`Connection error with backend ${this.socketIp}; Reason: ${error}`));
 };

--- a/lib/service/Backend.js
+++ b/lib/service/Backend.js
@@ -5,23 +5,24 @@ const
   util = require('util'),
   InternalError = require('kuzzle-common-objects').errors.InternalError;
 
+let _proxy;
+
 /**
  * Backend constructor
  *
  * @param {WebSocket} backendSocket
- * @param {Context} context
+ * @param {KuzzleProxy} proxy
  * @param {Number} backendTimeout
  * @constructor
  */
-function Backend (backendSocket, context, backendTimeout) {
+function Backend (backendSocket, proxy, backendTimeout) {
+  _proxy = proxy;
+
   /** @type {PendingRequest} */
   this.backendRequestStore = new PendingRequest(backendTimeout);
 
   /** @type {WebSocket} */
   this.socket = backendSocket;
-
-  /** @type {Context} */
-  this.context = context;
 
   /** @type {String} */
   this.socketIp = backendSocket.upgradeReq.connection.remoteAddress;
@@ -45,15 +46,15 @@ Backend.prototype.onMessage = function (payload) {
     message = JSON.parse(payload);
   }
   catch (error) {
-    return console.error(`Bad message received from the backend : ${payload}; Reason: ${error}`);
+    return _proxy.log.error(`Bad message received from the backend : ${payload}; Reason: ${error}`);
   }
 
   if (!message.room) {
-    return console.error(`Room is not specified in message: ${payload}`);
+    return _proxy.log.error(`Room is not specified in message: ${payload}`);
   }
 
   if (!this.onMessageRooms[message.room]) {
-    return console.error(`Unknown message type ${message.room}`);
+    return _proxy.log.error(`Unknown message type ${message.room}`);
   }
 
   this.onMessageRooms[message.room](message.data);
@@ -68,48 +69,48 @@ Backend.prototype.initializeMessageRooms = function () {
       this.backendRequestStore.resolve(data.requestId, null, data);
     },
     joinChannel: (data) => {
-      let client = this.context.clientConnectionStore.getByConnectionId(data.connectionId);
+      let client = _proxy.clientConnectionStore.getByConnectionId(data.connectionId);
 
       if (client && client.protocol) {
         try {
-          this.context.pluginStore.getByProtocol(client.protocol).joinChannel(data);
+          _proxy.pluginStore.getByProtocol(client.protocol).joinChannel(data);
         }
         catch (e) {
-          console.error(`[Join Channel] Plugin ${client.protocol} failed: ${e.message}`);
+          _proxy.log.error(`[Join Channel] Plugin ${client.protocol} failed: ${e.message}`);
         }
       }
     },
     leaveChannel: (data) => {
-      let client = this.context.clientConnectionStore.getByConnectionId(data.connectionId);
+      let client = _proxy.clientConnectionStore.getByConnectionId(data.connectionId);
 
       if (client && client.protocol) {
         try {
-          this.context.pluginStore.getByProtocol(client.protocol).leaveChannel(data);
+          _proxy.pluginStore.getByProtocol(client.protocol).leaveChannel(data);
         }
         catch (e) {
-          console.error(`[Leave Channel] Plugin ${client.type} failed: ${e.message}`);
+          _proxy.log.error(`[Leave Channel] Plugin ${client.type} failed: ${e.message}`);
         }
       }
     },
     notify: (data) => {
-      let client = this.context.clientConnectionStore.getByConnectionId(data.connectionId);
+      let client = _proxy.clientConnectionStore.getByConnectionId(data.connectionId);
 
       if (client && client.protocol) {
         try {
-          this.context.pluginStore.getByProtocol(client.protocol).notify(data);
+          _proxy.pluginStore.getByProtocol(client.protocol).notify(data);
         }
         catch (e) {
-          console.error(`[Notify] Plugin ${client.protocol} failed: ${e.message}\nNotification data:\n`, util.inspect(data, {depth: null}));
+          _proxy.log.error(`[Notify] Plugin ${client.protocol} failed: ${e.message}\nNotification data:\n`, util.inspect(data, {depth: null}));
         }
       }
     },
     broadcast: (data) => {
-      Object.keys(this.context.pluginStore.plugins).forEach(plugin => {
+      Object.keys(_proxy.pluginStore.plugins).forEach(plugin => {
         try {
-          this.context.pluginStore.plugins[plugin].broadcast(data);
+          _proxy.pluginStore.plugins[plugin].broadcast(data);
         }
         catch (e) {
-          console.error(`[Broadcast] Plugin ${this.context.pluginStore.plugins[plugin].protocol} failed: ${e.message}\nNotification data:\n`, util.inspect(data, {depth: null}));
+          _proxy.log.error(`[Broadcast] Plugin ${_proxy.pluginStore.plugins[plugin].protocol} failed: ${e.message}\nNotification data:\n`, util.inspect(data, {depth: null}));
         }
       });
     }
@@ -120,8 +121,8 @@ Backend.prototype.initializeMessageRooms = function () {
  * Triggered when the connection is closed
  */
 Backend.prototype.onConnectionClose = function () {
-  console.log(`Connection with backend ${this.socketIp} closed.`);
-  this.context.backendHandler.removeBackend(this);
+  _proxy.log.warn(`Connection with backend ${this.socketIp} closed.`);
+  _proxy.backendHandler.removeBackend(this);
   this.backendRequestStore.abortAll(new InternalError(`Connection with backend ${this.socketIp} closed.`));
 
   // We ensure the socket is closed to avoid weird side effects
@@ -134,8 +135,8 @@ Backend.prototype.onConnectionClose = function () {
  * @param {Error} error
  */
 Backend.prototype.onConnectionError = function(error) {
-  console.error(`Connection error with backend ${this.socketIp}; Reason:`, error);
-  this.context.backendHandler.removeBackend(this);
+  _proxy.log.error(`Connection error with backend ${this.socketIp}; Reason:`, error);
+  _proxy.backendHandler.removeBackend(this);
   this.backendRequestStore.abortAll(new InternalError(`Connection error with backend ${this.socketIp}; Reason: ${error}`));
 };
 

--- a/lib/service/Backend.js
+++ b/lib/service/Backend.js
@@ -69,7 +69,7 @@ Backend.prototype.initializeMessageRooms = function () {
       this.backendRequestStore.resolve(data.requestId, null, data);
     },
     joinChannel: (data) => {
-      let client = _proxy.clientConnectionStore.getByConnectionId(data.connectionId);
+      let client = _proxy.clientConnectionStore.get(data.connectionId);
 
       if (client && client.protocol) {
         try {
@@ -81,7 +81,7 @@ Backend.prototype.initializeMessageRooms = function () {
       }
     },
     leaveChannel: (data) => {
-      let client = _proxy.clientConnectionStore.getByConnectionId(data.connectionId);
+      let client = _proxy.clientConnectionStore.get(data.connectionId);
 
       if (client && client.protocol) {
         try {
@@ -93,7 +93,7 @@ Backend.prototype.initializeMessageRooms = function () {
       }
     },
     notify: (data) => {
-      let client = _proxy.clientConnectionStore.getByConnectionId(data.connectionId);
+      let client = _proxy.clientConnectionStore.get(data.connectionId);
 
       if (client && client.protocol) {
         try {

--- a/lib/service/Broker.js
+++ b/lib/service/Broker.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const
+let
   fs = require('fs'),
   http = require('http'),
   net = require('net'),
@@ -113,7 +113,7 @@ Broker.prototype.onConnection = function (backendSocket) {
   async.each(
     clientConnections,
     (clientConnection, callback) => backend.sendRaw('connection', clientConnection, callback),
-    error => this.handleBackendRegistration(backend, error)
+    error => this.handleBackendRegistration(error, backend)
   );
 };
 
@@ -123,10 +123,22 @@ Broker.prototype.onConnection = function (backendSocket) {
  * @param {Backend} backend
  * @param {Error|undefined} error
  */
-Broker.prototype.handleBackendRegistration = function (backend, error) {
+Broker.prototype.handleBackendRegistration = function (error, backend) {
   if (error) {
     // We presume the error comes from the socket connection and close it
-    _proxy.log.error(`Initialization of the connection with backend ${backend.socket.upgradeReq.connection.remoteAddress} failed; Reason: ${error.message}`);
+    let backendIdentifier = '';
+
+    if (this.config.socket) {
+      backendIdentifier = this.config.socket;
+    }
+    else {
+      if (this.config.host) {
+        backendIdentifier = this.config.host + ':';
+      }
+      backendIdentifier += this.config.port;
+    }
+
+    _proxy.log.error('Failed to init connection with backend %s:\n%s', backendIdentifier, error.stack);
     backend.socket.close();
   }
   else {
@@ -140,7 +152,7 @@ Broker.prototype.handleBackendRegistration = function (backend, error) {
  * @param {Error} error
  */
 Broker.prototype.onError = function (error) {
-  _proxy.log.error('An error occurred with the broker socket, shutting down; Reason :', error);
+  _proxy.log.error('An error occurred with the broker socket, shutting down; Reason:\n%s', error.stack);
   process.exit(1);
 };
 
@@ -192,7 +204,7 @@ Broker.prototype.removeClientConnection = function (connection) {
     protocol: connection.protocol
   });
   this.broadcastMessage('disconnect', context);
-  _proxy.clientConnectionStore.remove(context);
+  _proxy.clientConnectionStore.remove(connection.id);
 };
 
 /**

--- a/lib/service/Broker.js
+++ b/lib/service/Broker.js
@@ -126,7 +126,7 @@ Broker.prototype.onConnection = function (backendSocket) {
 Broker.prototype.handleBackendRegistration = function (error, backend) {
   if (error) {
     // We presume the error comes from the socket connection and close it
-    let backendIdentifier = '';
+    let backendIdentifier;
 
     if (this.config.socket) {
       backendIdentifier = this.config.socket;
@@ -134,6 +134,9 @@ Broker.prototype.handleBackendRegistration = function (error, backend) {
     else {
       if (this.config.host) {
         backendIdentifier = this.config.host + ':';
+      }
+      else {
+        backendIdentifier = '0.0.0.0:';
       }
       backendIdentifier += this.config.port;
     }

--- a/lib/service/Broker.js
+++ b/lib/service/Broker.js
@@ -184,9 +184,13 @@ Broker.prototype.addClientConnection = function (connection) {
 /**
  * Removes a client connection and spreads the word to all backends
  *
- * @param {RequestContext} context
+ * @param {ClientConnection} context
  */
-Broker.prototype.removeClientConnection = function (context) {
+Broker.prototype.removeClientConnection = function (connection) {
+  const context = new RequestContext({
+    connectionId: connection.id,
+    protocol: connection.protocol
+  });
   this.broadcastMessage('disconnect', context);
   _proxy.clientConnectionStore.remove(context);
 };

--- a/lib/service/Broker.js
+++ b/lib/service/Broker.js
@@ -1,13 +1,18 @@
 'use strict';
 
-let
+const
   fs = require('fs'),
   http = require('http'),
   net = require('net'),
   WebSocketServer = require('ws').Server,
   Backend = require('./Backend'),
   async = require('async'),
+  RequestContext = require('kuzzle-common-objects').models.RequestContext,
   ServiceUnavailableError = require('kuzzle-common-objects').errors.ServiceUnavailableError;
+
+let
+  _proxy;
+
 
 /**
  * Broker constructor
@@ -15,7 +20,7 @@ let
  * @constructor
  */
 function Broker () {
-  this.context = null;
+  this.config = null;
   this.socketOptions = null;
   this.backendHandler = null;
 }
@@ -23,11 +28,12 @@ function Broker () {
 /**
  * Initializes the Broker
  *
- * @param {Context} context
+ * @param {KuzzleProxy} proxy
  * @param {Object} config
  */
-Broker.prototype.init = function (context, config) {
-  this.context = context;
+Broker.prototype.init = function (proxy, config) {
+  _proxy = proxy;
+
   this.config = config;
 
   this.initiateServer();
@@ -82,7 +88,7 @@ Broker.prototype.initiateServer = function () {
     }
   }
   else {
-    console.error('Invalid configuration provided. Either "socket" or "port" must be provided.');
+    _proxy.log.error('Invalid configuration provided. Either "socket" or "port" must be provided.');
     process.exit(1);
   }
 };
@@ -94,14 +100,14 @@ Broker.prototype.initiateServer = function () {
  */
 Broker.prototype.onConnection = function (backendSocket) {
   let
-    backend = new Backend(backendSocket, this.context, this.config.timeout),
-    clientConnections = this.context.clientConnectionStore.getAll();
+    backend = new Backend(backendSocket, _proxy, this.config.timeout),
+    clientConnections = _proxy.clientConnectionStore.getAll();
 
   if (this.config.socket) {
-    console.log('Connection established with a new backend');
+    _proxy.log.info('Connection established with a new backend');
   }
   else {
-    console.log(`A connection has been established with backend ${backendSocket.upgradeReq.connection.remoteAddress}.`);
+    _proxy.log.info(`A connection has been established with backend ${backendSocket.upgradeReq.connection.remoteAddress}.`);
   }
 
   async.each(
@@ -120,11 +126,11 @@ Broker.prototype.onConnection = function (backendSocket) {
 Broker.prototype.handleBackendRegistration = function (backend, error) {
   if (error) {
     // We presume the error comes from the socket connection and close it
-    console.error(`Initialization of the connection with backend ${backend.socket.upgradeReq.connection.remoteAddress} failed; Reason: ${error.message}`);
+    _proxy.log.error(`Initialization of the connection with backend ${backend.socket.upgradeReq.connection.remoteAddress} failed; Reason: ${error.message}`);
     backend.socket.close();
   }
   else {
-    this.context.backendHandler.addBackend(backend);
+    _proxy.backendHandler.addBackend(backend);
   }
 };
 
@@ -134,38 +140,45 @@ Broker.prototype.handleBackendRegistration = function (backend, error) {
  * @param {Error} error
  */
 Broker.prototype.onError = function (error) {
-  console.error('An error occurred with the broker socket, shutting down; Reason :', error);
+  _proxy.log.error('An error occurred with the broker socket, shutting down; Reason :', error);
   process.exit(1);
 };
-
 
 /**
  * Sends the client's message to one of the backends
  *
  * @param {string} room - target Kuzzle server room
  * @param {string} id - request id
+ * @param {string} connectionId - connection id
  * @param {Object} data - request data to deliver to Kuzzle
  * @param {Function} callback - Client's callback to resolve
  */
-Broker.prototype.brokerCallback = function (room, id, data, callback) {
-  let backend = this.context.backendHandler.getBackend();
+Broker.prototype.brokerCallback = function (room, id, connectionId, data, callback) {
+  const backend = _proxy.backendHandler.getBackend();
 
   if (!backend) {
     callback(new ServiceUnavailableError('No Kuzzle instance found'));
   }
   else {
-    backend.send(room, id, data, callback);
+    backend.send(room, id, data, (error, result) => {
+      _proxy.logAccess(connectionId, data, error, result);
+      callback(error, result);
+    });
   }
 };
 
 /**
  * Adds a client connection and spreads the word to all backends
  *
- * @param {RequestContext} context
+ * @param {ClientConnection} connection
  */
-Broker.prototype.addClientConnection = function (context) {
+Broker.prototype.addClientConnection = function (connection) {
+  const context = new RequestContext({
+    connectionId: connection.id,
+    protocol: connection.protocol
+  });
   this.broadcastMessage('connection', context);
-  this.context.clientConnectionStore.add(context);
+  _proxy.clientConnectionStore.add(connection);
 };
 
 /**
@@ -175,7 +188,7 @@ Broker.prototype.addClientConnection = function (context) {
  */
 Broker.prototype.removeClientConnection = function (context) {
   this.broadcastMessage('disconnect', context);
-  this.context.clientConnectionStore.remove(context);
+  _proxy.clientConnectionStore.remove(context);
 };
 
 /**
@@ -185,7 +198,7 @@ Broker.prototype.removeClientConnection = function (context) {
  * @param {object} data
  */
 Broker.prototype.broadcastMessage = function (room, data) {
-  this.context.backendHandler.getAllBackends().forEach(backend => backend.sendRaw(room, data));
+  _proxy.backendHandler.getAllBackends().forEach(backend => backend.sendRaw(room, data));
 };
 
 module.exports = Broker;

--- a/lib/service/HttpProxy.js
+++ b/lib/service/HttpProxy.js
@@ -144,6 +144,8 @@ function sendRequest (connectionId, response, payload) {
 /**
  * Forward an error response to the client
  *
+ * @param {string} connectionId
+ * @param {Object} payload
  * @param {Object} response
  * @param {Object} error
  */

--- a/lib/service/HttpProxy.js
+++ b/lib/service/HttpProxy.js
@@ -133,7 +133,7 @@ function sendRequest (connectionId, response, payload) {
         return response.end(result.content);
       }
 
-      response.end(JSON.stringify(result, undefined, indent));
+      response.end(JSON.stringify(result.content, undefined, indent));
     }
     else {
       replyWithError(connectionId, payload, response, error);

--- a/lib/service/HttpProxy.js
+++ b/lib/service/HttpProxy.js
@@ -5,8 +5,11 @@ const
   bytes = require('bytes'),
   uuid = require('uuid'),
   url = require('url'),
+  ClientConnection = require('../core/clientConnection'),
   SizeLimitError = require('kuzzle-common-objects').errors.SizeLimitError,
   KuzzleRoom = 'httpRequest';
+
+const _proxy = {};
 
 /**
  * @returns {HttpProxy}
@@ -22,18 +25,19 @@ function HttpProxy () {
 /**
  * Initializes the HTTP server
  *
- * @param context
- * @param config
+ * @param {KuzzleProxy} proxy
  */
-HttpProxy.prototype.init = function (context, config) {
-  this.maxRequestSize = bytes.parse(config.http.maxRequestSize);
-  this.accessControlAllowOrigin = config.http.accessControlAllowOrigin;
+HttpProxy.prototype.init = function (proxy) {
+  this.maxRequestSize = bytes.parse(proxy.config.http.maxRequestSize);
+  this.accessControlAllowOrigin = proxy.config.http.accessControlAllowOrigin;
+
+  Object.assign(_proxy, proxy);
 
   if (this.maxRequestSize === null || isNaN(this.maxRequestSize)) {
     throw new Error('Invalid HTTP "maxRequestSize" parameter');
   }
 
-  if (!config.http.port) {
+  if (!proxy.config.http.port) {
     throw new Error('No HTTP port configured.');
   }
 
@@ -46,6 +50,17 @@ HttpProxy.prototype.init = function (context, config) {
         headers: request.headers,
         content: ''
       };
+
+    let ips = [request.socket.remoteAddress];
+    if (request.headers['x-forwarded-for']) {
+      ips = request.headers['x-forwarded-for']
+        .split(',')
+        .map(s => s.trim())
+        .concat(ips);
+    }
+
+    const connection = new ClientConnection('http', ips, request.headers);
+    _proxy.clientConnectionStore.add(connection);
 
     if (request.method.toUpperCase() === 'OPTIONS') {
       response.writeHead(200, {
@@ -83,24 +98,26 @@ HttpProxy.prototype.init = function (context, config) {
     });
 
     request.on('end', () => {
-      sendRequest(context, this.accessControlAllowOrigin, response, payload);
+      sendRequest(this.accessControlAllowOrigin, connection.id, response, payload);
     });
   });
 
-  this.server.listen(config.http.port, config.http.host);
+  this.server.listen(proxy.config.http.port, proxy.config.http.host);
 };
 
 /**
  * Sends a request to Kuzzle and forwards the response back to the client
  *
- * @param {Context} context
  * @param {string} allowOrigin - CORS header value
- * @param {http.ServerResponse} response
+ * @param {connectionId} connectionId - connection Id
+ * @param {ServerResponse} response
  * @param {Object} payload
  */
-function sendRequest (context, allowOrigin, response, payload) {
-  context.broker.brokerCallback(KuzzleRoom, payload.requestId, payload, (error, result) => {
+function sendRequest (allowOrigin, connectionId, response, payload) {
+  _proxy.broker.brokerCallback(KuzzleRoom, payload.requestId, connectionId, payload, (error, result) => {
     if (result) {
+      _proxy.clientConnectionStore.remove(connectionId);
+
       let indent = 0;
       const parsedUrl = url.parse(payload.url, true);
 

--- a/lib/service/HttpProxy.js
+++ b/lib/service/HttpProxy.js
@@ -57,7 +57,7 @@ HttpProxy.prototype.init = function (proxy) {
         .concat(ips);
     }
 
-    const connection = new ClientConnection('http', ips, request.headers);
+    const connection = new ClientConnection('HTTP/' + request.httpVersion, ips, request.headers);
     _proxy.clientConnectionStore.add(connection);
 
     if (request.headers['content-length'] > this.maxRequestSize) {
@@ -109,25 +109,25 @@ function sendRequest (connectionId, response, payload) {
         indent = 2;
       }
 
-      if (result.response.headers) {
-        Object.keys(result.response.headers)
+      if (result.headers) {
+        Object.keys(result.headers)
           .forEach(header => {
-            response.setHeader(header, result.response.headers[header]);
+            response.setHeader(header, result.headers[header]);
           });
       }
 
       response.writeHead(result.status);
 
-      if (result.response.raw || result.response instanceof Buffer) {
-        if (typeof result.response.content === 'object') {
-          response.end(JSON.stringify(result.response.content));
+      if (result.raw || result.content instanceof Buffer) {
+        if (typeof result.content === 'object') {
+          response.end(JSON.stringify(result.content));
         }
         else {
-          response.end(Buffer.from(result.response.content));
+          response.end(Buffer.from(result.content));
         }
       }
       else {
-        response.end(JSON.stringify(result.response, undefined, indent));
+        response.end(JSON.stringify(result, undefined, indent));
       }
     }
     else {

--- a/lib/service/HttpProxy.js
+++ b/lib/service/HttpProxy.js
@@ -131,7 +131,7 @@ function sendRequest (connectionId, response, payload) {
       }
     }
     else {
-      replyWithError(allowOrigin, response, error);
+      replyWithError(response, error);
     }
   });
 }

--- a/lib/service/HttpProxy.js
+++ b/lib/service/HttpProxy.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const
+let
   http = require('http'),
   bytes = require('bytes'),
   uuid = require('uuid'),
@@ -62,7 +62,7 @@ HttpProxy.prototype.init = function (proxy) {
 
     if (request.headers['content-length'] > this.maxRequestSize) {
       request.resume();
-      return replyWithError(response, new SizeLimitError('Error: maximum HTTP request size exceeded'));
+      return replyWithError(connection.id, payload, response, new SizeLimitError('Error: maximum HTTP request size exceeded'));
     }
 
     request.on('data', chunk => {
@@ -78,7 +78,7 @@ HttpProxy.prototype.init = function (proxy) {
           .removeAllListeners('data')
           .removeAllListeners('end')
           .resume();
-        return replyWithError(response, new SizeLimitError('Error: maximum HTTP request size exceeded'));
+        return replyWithError(connection.id, payload, response, new SizeLimitError('Error: maximum HTTP request size exceeded'));
       }
     });
 
@@ -118,20 +118,25 @@ function sendRequest (connectionId, response, payload) {
 
       response.writeHead(result.status);
 
-      if (result.raw || result.content instanceof Buffer) {
+      if (result.raw) {
+        // binary data are sent as-is
+        if (result.content instanceof Buffer) {
+          return response.end(result.content);
+        }
+
+        // all JS objects are serialized, including arrays
         if (typeof result.content === 'object') {
-          response.end(JSON.stringify(result.content));
+          return response.end(JSON.stringify(result.content));
         }
-        else {
-          response.end(Buffer.from(result.content));
-        }
+
+        // scalars are sent as-is
+        return response.end(result.content);
       }
-      else {
-        response.end(JSON.stringify(result, undefined, indent));
-      }
+
+      response.end(JSON.stringify(result, undefined, indent));
     }
     else {
-      replyWithError(response, error);
+      replyWithError(connectionId, payload, response, error);
     }
   });
 }
@@ -142,7 +147,14 @@ function sendRequest (connectionId, response, payload) {
  * @param {Object} response
  * @param {Object} error
  */
-function replyWithError(response, error) {
+function replyWithError(connectionId, payload, response, error) {
+  const result = {
+    raw: true,
+    content: JSON.stringify(error)
+  };
+
+  _proxy.logAccess(connectionId, payload, error, result);
+
   response.writeHead(error.status, {
     'Content-Type': 'application/json',
     'Access-Control-Allow-Origin': '*',
@@ -150,7 +162,7 @@ function replyWithError(response, error) {
     'Access-Control-Allow-Headers': 'Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With'
   });
 
-  response.end(JSON.stringify(error));
+  response.end(result.content);
 }
 
 module.exports = HttpProxy;

--- a/lib/service/Router.js
+++ b/lib/service/Router.js
@@ -3,7 +3,8 @@
 const
   ServiceUnavailableError = require('kuzzle-common-objects').errors.ServiceUnavailableError;
 
-const _proxy = {};
+let _proxy;
+
 /**
  * Router constructor
  *
@@ -11,7 +12,7 @@ const _proxy = {};
  * @constructor
  */
 function Router (proxy) {
-  Object.assign(_proxy, proxy);
+  _proxy = proxy;
 }
 
 /**
@@ -51,7 +52,7 @@ Router.prototype.execute = function (request, callback) {
  * @param {string} connectionId
  */
 Router.prototype.removeConnection = function (connectionId) {
-  const connection = _proxy.clientConnectionStore.getByConnectionId(connectionId);
+  const connection = _proxy.clientConnectionStore.get(connectionId);
 
   if (connection) {
     _proxy.broker.removeClientConnection(connection);

--- a/lib/service/Router.js
+++ b/lib/service/Router.js
@@ -48,10 +48,12 @@ Router.prototype.execute = function (request, callback) {
 /**
  * Triggered when a plugin connection is closed
  *
- * @param {RequestContext} connection
+ * @param {string} connectionId
  */
-Router.prototype.removeConnection = function (connection) {
-  if (_proxy.clientConnectionStore.get(connection)) {
+Router.prototype.removeConnection = function (connectionId) {
+  const connection = _proxy.clientConnectionStore.getByConnectionId(connectionId);
+
+  if (connection) {
     _proxy.broker.removeClientConnection(connection);
   }
 };

--- a/lib/service/Router.js
+++ b/lib/service/Router.js
@@ -1,43 +1,31 @@
 'use strict';
 
 const
-  Promise = require('bluebird'),
-  RequestContext = require('kuzzle-common-objects').models.RequestContext,
   ServiceUnavailableError = require('kuzzle-common-objects').errors.ServiceUnavailableError;
 
+const _proxy = {};
 /**
  * Router constructor
  *
- * @param {Context} context
+ * @param {KuzzleProxy} proxy
  * @constructor
  */
-function Router (context) {
-  this.context = context;
+function Router (proxy) {
+  Object.assign(_proxy, proxy);
 }
 
 /**
  * Triggered when a plugin gets a new connection
  *
- * @param {string} protocol
- * @param {string} connectionId
- * @returns {Promise}
+ * @param {ClientConnection} connection
  */
-Router.prototype.newConnection = function (protocol, connectionId) {
-  let
-    context = new RequestContext({protocol, connectionId}),
-    currentConnection;
-
+Router.prototype.newConnection = function (connection) {
   // Reject the connection if no backend is available
-  if (!this.context.backendHandler.getBackend()) {
-    return Promise.reject(new ServiceUnavailableError('No Kuzzle instance found'));
+  if (!_proxy.backendHandler.getBackend()) {
+    throw new ServiceUnavailableError('No Kuzzle instance found');
   }
 
-  currentConnection = this.context.clientConnectionStore.get(context);
-  if (!currentConnection || context.protocol !== currentConnection.protocol) {
-    this.context.broker.addClientConnection(context);
-  }
-
-  return Promise.resolve(context);
+  _proxy.broker.addClientConnection(connection);
 };
 
 /**
@@ -47,7 +35,7 @@ Router.prototype.newConnection = function (protocol, connectionId) {
  * @param {Function} callback
  */
 Router.prototype.execute = function (request, callback) {
-  this.context.broker.brokerCallback('request', request.id, request.serialize(), (error, result) => {
+  _proxy.broker.brokerCallback('request', request.id, request.context.connectionId, request.serialize(), (error, result) => {
     if (error) {
       request.setError(error);
       return callback(request.response);
@@ -63,8 +51,8 @@ Router.prototype.execute = function (request, callback) {
  * @param {RequestContext} connection
  */
 Router.prototype.removeConnection = function (connection) {
-  if (this.context.clientConnectionStore.get(connection)) {
-    this.context.broker.removeClientConnection(connection);
+  if (_proxy.clientConnectionStore.get(connection)) {
+    _proxy.broker.removeClientConnection(connection);
   }
 };
 

--- a/lib/store/ClientConnection.js
+++ b/lib/store/ClientConnection.js
@@ -4,60 +4,56 @@
  * @constructor
  */
 function ClientConnection () {
-  /** @type {RequestContext[]} */
+  /** @type {ClientConnection[]} */
   this.clientConnections = {};
 }
 
 /**
  * Adds a connection to the store
  *
- * @param {RequestContext} connection
+ * @param {ClientConnection} connection
  */
 ClientConnection.prototype.add = function (connection) {
-  if (connection.connectionId) {
-    this.clientConnections[connection.connectionId] = connection;
-  }
+  this.clientConnections[connection.id] = connection;
 };
 
 /**
  * Removes a connection from the store
  *
- * @param {RequestContext} connection
+ * @param {string} connectionId
  */
-ClientConnection.prototype.remove = function (connection) {
-  if (connection.connectionId && this.clientConnections[connection.connectionId]) {
-    delete this.clientConnections[connection.connectionId];
+ClientConnection.prototype.remove = function (connectionId) {
+  if (this.clientConnections[connectionId]) {
+    delete this.clientConnections[connectionId];
   }
 };
 
 /**
  * Gets a connection from the store
  *
- * @param {RequestContext} connection
- * @returns {RequestContext}
+ * @param {ClientConnection} connection
+ * @returns {ClientConnection}
  */
 ClientConnection.prototype.get = function (connection) {
-  if (connection.connectionId) {
-    return this.clientConnections[connection.connectionId];
+  if (connection) {
+    return this.clientConnections[connection.id];
   }
-
-  return undefined;
 };
 
 /**
  * Gets a connection from the store by connectionId
  *
  * @param {String} id
- * @returns {RequestContext}
+ * @returns {ClientConnection}
  */
 ClientConnection.prototype.getByConnectionId = function (id) {
   return this.clientConnections[id];
 };
 
 /**
- * Retuns all client connections from the store
+ * Returns all client connections from the store
  *
- * @returns {RequestContext[]}
+ * @returns {ClientConnection[]}
  */
 ClientConnection.prototype.getAll = function () {
   return this.clientConnections;

--- a/lib/store/ClientConnection.js
+++ b/lib/store/ClientConnection.js
@@ -29,34 +29,23 @@ ClientConnection.prototype.remove = function (connectionId) {
 };
 
 /**
- * Gets a connection from the store
- *
- * @param {ClientConnection} connection
- * @returns {ClientConnection}
- */
-ClientConnection.prototype.get = function (connection) {
-  if (connection) {
-    return this.clientConnections[connection.id];
-  }
-};
-
-/**
  * Gets a connection from the store by connectionId
  *
  * @param {String} id
  * @returns {ClientConnection}
  */
-ClientConnection.prototype.getByConnectionId = function (id) {
+ClientConnection.prototype.get = function (id) {
   return this.clientConnections[id];
 };
 
 /**
- * Returns all client connections from the store
+ * Returns all client connections from the store as an Array
  *
  * @returns {ClientConnection[]}
  */
 ClientConnection.prototype.getAll = function () {
-  return this.clientConnections;
+  return Object.keys(this.clientConnections)
+    .map(id => this.clientConnections[id]);
 };
 
 module.exports = ClientConnection;

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "lodash": "^4.14.1",
     "moment": "^2.17.1",
     "proper-lockfile": "^2.0.0",
-    "proxyquire": "^1.7.10",
     "rc": "^1.1.6",
     "utf-8-validate": "^1.2.1",
     "uuid": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "uuid": "3.0.0",
     "winston": "^2.3.0",
     "winston-elasticsearch": "^0.4.2",
+    "winston-syslog": "^1.2.5",
     "ws": "^1.1.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -29,11 +29,14 @@
     "compare-versions": "^3.0.0",
     "kuzzle-common-objects": "2.0.1",
     "lodash": "^4.14.1",
-    "uuid": "3.0.0",
+    "moment": "^2.17.1",
     "proper-lockfile": "^2.0.0",
     "proxyquire": "^1.7.10",
     "rc": "^1.1.6",
     "utf-8-validate": "^1.2.1",
+    "uuid": "3.0.0",
+    "winston": "^2.3.0",
+    "winston-elasticsearch": "^0.4.2",
     "ws": "^1.1.1"
   },
   "devDependencies": {

--- a/test/core/clientConnection.test.js
+++ b/test/core/clientConnection.test.js
@@ -1,0 +1,12 @@
+const
+  should = require('should'),
+  ClientConnection = require('../../lib/core/clientConnection');
+
+describe('core/clientConnection', () => {
+  describe('#constructor', () => {
+    it('should throw if ips is not an array', () => {
+      return should(() => new ClientConnection('protocol', 'ips'))
+        .throw(TypeError, {message: 'Expected ips to be an Array, got string'});
+    });
+  });
+});

--- a/test/core/context.test.js
+++ b/test/core/context.test.js
@@ -5,10 +5,7 @@ const
   should = require('should'),
   ClientConnection = require('../../lib/core/clientConnection'),
   Context = require('../../lib/core/Context'),
-  sinon = require('sinon'),
-  rewire = require('rewire'),
-  Request = require('kuzzle-common-objects').Request,
-  Router = require.main.require('lib/service/Router');
+  Request = require('kuzzle-common-objects').Request;
 
 describe('Test: core/Context', function () {
 

--- a/test/core/context.test.js
+++ b/test/core/context.test.js
@@ -1,66 +1,37 @@
-var
+'use strict';
+
+const
+  errors = require('kuzzle-common-objects').errors,
   should = require('should'),
-  Context = require.main.require('lib/core/Context'),
-  ClientConnectionStore = require.main.require('lib/store/ClientConnection'),
-  PluginStore = require.main.require('lib/store/Plugin'),
+  ClientConnection = require('../../lib/core/clientConnection'),
+  Context = require('../../lib/core/Context'),
   sinon = require('sinon'),
   rewire = require('rewire'),
+  Request = require('kuzzle-common-objects').Request,
   Router = require.main.require('lib/service/Router');
 
 describe('Test: core/Context', function () {
-  var
-    dummyBroker = {dummy: 'broker'},
-    backendMode = 'aMode',
-    BackendHandler,
-    sandbox;
-
-  before(() => {
-    sandbox = sinon.sandbox.create();
-    BackendHandler = sandbox.spy(function (mode) {
-      should(mode).be.eql(backendMode);
-    });
-  });
-
-  afterEach(() => {
-    sandbox.restore();
-  });
 
   it('constructor must initialize internal members', () => {
-    var context = new Context(BackendHandler, backendMode);
+    const context = new Context({foo: 'bar'});
 
-    should(context.broker).be.eql(null);
-    should(context.clientConnectionStore).be.instanceOf(ClientConnectionStore);
-    should(BackendHandler.calledWithNew()).be.true();
-    should(BackendHandler.calledWith(backendMode)).be.true();
-    should(context.pluginStore).be.instanceOf(PluginStore);
-    should(context.router).be.instanceOf(Router);
-  });
-
-  it('method setBroker must set broker accordingly', () => {
-    var context = new Context(BackendHandler, backendMode);
-
-    context.setBroker(dummyBroker);
-
-    should(context.broker).be.deepEqual(dummyBroker);
+    should(context.constructors.ClientConnection)
+      .be.exactly(ClientConnection);
+    should(context.constructors.Request)
+      .be.exactly(Request);
+    should(context.errors)
+      .be.exactly(errors);
   });
 
   it('method getRouter must return the router', () => {
-    var context = new Context(BackendHandler, backendMode);
+    const
+      proxy = {
+        router: {foo: 'bar'}
+      },
+      context = new Context(proxy);
 
-    should(context.accessors.router).be.deepEqual(context.router);
+    should (context.accessors.router)
+      .be.exactly(proxy.router);
   });
 
-  it('should dynamically add kuzzle error constructors', () => {
-    var
-      RewiredContext = rewire('../../lib/core/Context'),
-      context,
-      fakeErrorObject = {
-        'FooBar': function () {}
-      };
-
-    RewiredContext.__set__('errors', fakeErrorObject);
-
-    context = new RewiredContext(BackendHandler, backendMode);
-    should(context.errors).have.property('FooBar', fakeErrorObject.FooBar);
-  });
 });

--- a/test/core/context.test.js
+++ b/test/core/context.test.js
@@ -31,4 +31,17 @@ describe('Test: core/Context', function () {
       .be.exactly(proxy.router);
   });
 
+  it('log getter should return the proxy error logger', () => {
+    const
+      proxy = {
+        loggers: {
+          error: {foo: 'bar'}
+        }
+      };
+
+    const context = new Context(proxy);
+    should(context.log)
+      .be.exactly(proxy.loggers.errors);
+  });
+
 });

--- a/test/core/kuzzleProxy.test.js
+++ b/test/core/kuzzleProxy.test.js
@@ -294,7 +294,7 @@ describe('lib/core/KuzzleProxy', () => {
         access: {
           info: sinon.spy()
         }
-      }
+      };
     });
 
     it('should trigger an warn log if no connection could be found', () => {
@@ -327,13 +327,13 @@ describe('lib/core/KuzzleProxy', () => {
           request,
           error,
           result
-      });
+        });
     });
 
     it('should output combined logs from an http request', () => {
       const
         connection = {
-          protocol: 'http',
+          protocol: 'HTTP/1.1',
           headers: {
             authorization: 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJfaWQiOiJhZG1pbiIsImlhdCI6MTQ4MjE3MDQwNywiZXhwIjoxNDgyMTg0ODA3fQ.SmLTFuIPsVuA8Pgpf9XONW2RtxcHjQffthNZ5Er4L4s',
             referer: 'http://referer.com',
@@ -343,7 +343,11 @@ describe('lib/core/KuzzleProxy', () => {
         },
         request = {
           url: 'url',
-          method: 'METHOD'
+          method: 'METHOD',
+          data: {
+            index: 'index',
+            collection: 'collection'
+          }
         },
         result = {
           status: 'status'
@@ -357,7 +361,7 @@ describe('lib/core/KuzzleProxy', () => {
 
       should(proxy.loggers.access.info)
         .be.calledOnce()
-        .be.calledWithMatch(/^1.1.1.1 - admin \[\d\d\/[A-Z][a-z]{2}\/\d{4}:\d\d:\d\d:\d\d [+-]\d{4}] "METHOD url HTTP" status 19 "http:\/\/referer.com" "user agent"$/);
+        .be.calledWithMatch(/^1\.1\.1\.1 - admin \[\d\d\/[A-Z][a-z]{2}\/\d{4}:\d\d:\d\d:\d\d [+-]\d{4}] "METHOD url HTTP\/1\.1" status 9 "http:\/\/referer.com" "user agent"$/);
     });
 
     it('should use the error status in priority', () => {
@@ -393,14 +397,14 @@ describe('lib/core/KuzzleProxy', () => {
       proxy.logAccess(1, request, error, result);
       should(proxy.loggers.access.info)
         .be.calledOnce()
-        .be.calledWithMatch(/^2.2.2.2 - admin \[\d\d\/[A-Z][a-z]{2}\/\d{4}:\d\d:\d\d:\d\d [+-]\d{4}] "DO \/controller\/action\/index\/collection\/id WEBSOCKET" 500 19 "http:\/\/referer.com" "user agent"/)
+        .be.calledWithMatch(/^2\.2\.2\.2 - admin \[\d\d\/[A-Z][a-z]{2}\/\d{4}:\d\d:\d\d:\d\d [+-]\d{4}] "DO \/controller\/action\/index\/collection\/id WEBSOCKET" 500 9 "http:\/\/referer\.com" "user agent"/);
 
       error.status = 'ERR';
       proxy.logAccess(1, request, error, result);
       should(proxy.loggers.access.info)
         .be.calledTwice();
       should(proxy.loggers.access.info.secondCall.args[0])
-        .match(/^2.2.2.2 - admin \[\d\d\/[A-Z][a-z]{2}\/\d{4}:\d\d:\d\d:\d\d [+-]\d{4}] "DO \/controller\/action\/index\/collection\/id WEBSOCKET" ERR 19 "http:\/\/referer.com" "user agent"/)
+        .match(/^2\.2\.2\.2 - admin \[\d\d\/[A-Z][a-z]{2}\/\d{4}:\d\d:\d\d:\d\d [+-]\d{4}] "DO \/controller\/action\/index\/collection\/id WEBSOCKET" ERR 9 "http:\/\/referer\.com" "user agent"/);
     });
 
   });

--- a/test/core/kuzzleProxy.test.js
+++ b/test/core/kuzzleProxy.test.js
@@ -1,73 +1,107 @@
-var
+'use strict';
+
+const
+  _ = require('lodash'),
   rewire = require('rewire'),
   should = require('should'),
   sinon = require('sinon'),
   Promise = require('bluebird'),
-  KuzzleProxy = rewire('../../lib/core/KuzzleProxy');
+  KuzzleProxy = rewire('../../lib/core/KuzzleProxy'),
+  proxyConfig = require('../../lib/core/config');
 
 describe('lib/core/KuzzleProxy', () => {
-  var
-    backendHandler = {foo: 'bar'},
+  let
+    BackendHandler = sinon.spy(),
     reset,
-    proxy;
+    proxy,
+    winstonTransportConsole,
+    winstonTransportFile,
+    winstonTransportElasticsearch,
+    winstonTransportSyslog;
 
   beforeEach(() => {
+    winstonTransportConsole = sinon.spy();
+    winstonTransportElasticsearch = sinon.spy();
+    winstonTransportFile = sinon.spy();
+    winstonTransportSyslog = sinon.spy();
+
     reset = KuzzleProxy.__set__({
-      console: {
-        log: sinon.spy(),
-        error: sinon.spy()
-      },
+      config: _.cloneDeep(proxyConfig),
       Broker: sinon.spy(function () {
         this.init = sinon.spy();                // eslint-disable-line no-invalid-this
       }),
-      Context: sinon.spy(function (backend, mode) {
-        this.backend = backend;                 // eslint-disable-line no-invalid-this
-        this.mode = mode;                       // eslint-disable-line no-invalid-this
-        this.pluginStore = {                    // eslint-disable-line no-invalid-this
-          add: sinon.spy(),
-          count: sinon.stub().returns(2)
-        };
-        this.setBroker = sinon.spy();           // eslint-disable-line no-invalid-this
-      }),
+      Context: sinon.spy(),
       HttpProxy: sinon.spy(function () {
         this.init = sinon.spy();                // eslint-disable-line no-invalid-this
       }),
       PluginPackage: sinon.spy(function () {
         this.needsInstall = sinon.stub().returns(true);   // eslint-disable-line no-invalid-this
         this.install = sinon.stub().returns(Promise.resolve((function () { return this; })())); // eslint-disable-line no-invalid-this
-      })
+      }),
+      winston: {
+        Logger: sinon.spy(),
+        transports: {
+          Console: winstonTransportConsole,
+          File: winstonTransportFile
+        }
+      },
+      WinstonElasticsearch: winstonTransportElasticsearch,
+      WinstonSyslog: winstonTransportSyslog
     });
 
-    proxy = new KuzzleProxy(backendHandler);
+    proxy = new KuzzleProxy(BackendHandler);
+
+    Object.defineProperty(proxy, 'log', {
+      enumerable: true,
+      value: {
+        info: sinon.spy(),
+        warn: sinon.spy(),
+        error: sinon.spy()
+      }
+    });
   });
 
   afterEach(() => {
     reset();
   });
 
+  describe('#log getter', () => {
+    it('should return the error logger', () => {
+      proxy = new KuzzleProxy(BackendHandler);
+      proxy.loggers = {
+        errors: {foo: 'bar'}
+      };
+
+      should(proxy.log)
+        .be.exactly(proxy.loggers.errors);
+    });
+  });
+
   describe('#start', () => {
     it('should call proper methods in order', () => {
+      proxy.initLogger = sinon.spy();
       proxy.installPluginsIfNeeded = sinon.stub().returns(Promise.resolve());
       proxy.initPlugins = sinon.spy();
-      proxy.initBroker = sinon.spy();
-      proxy.initHttpProxy = sinon.spy();
 
       return proxy.start()
         .then(() => {
+          should(proxy.initLogger)
+            .be.calledOnce();
           should(proxy.installPluginsIfNeeded)
             .be.calledOnce();
           should(proxy.initPlugins)
             .be.calledOnce();
-          should(proxy.initBroker)
+          should(proxy.broker.init)
             .be.calledOnce();
-          should(proxy.initHttpProxy)
+          should(proxy.httpProxy.init)
             .be.calledOnce();
 
           sinon.assert.callOrder(
+            proxy.initLogger,
             proxy.installPluginsIfNeeded,
             proxy.initPlugins,
-            proxy.initBroker,
-            proxy.initHttpProxy
+            proxy.broker.init,
+            proxy.httpProxy.init
           );
         });
     });
@@ -90,9 +124,23 @@ describe('lib/core/KuzzleProxy', () => {
   });
 
   describe('#initPlugins', () => {
+    it ('should not installed plugins not marked as active', () => {
+      proxy.config.protocolPlugins = {
+        foo: {
+          activated: false
+        }
+      };
+
+      proxy.initPlugins();
+
+      should(proxy.log.info)
+        .have.callCount(0);
+    });
+
     it('should init plugins', () => {
-      var
+      const
         pkg = {
+          protocol: 'protocol',
           init: sinon.spy()
         };
 
@@ -112,66 +160,250 @@ describe('lib/core/KuzzleProxy', () => {
           .be.calledOnce()
           .be.calledWith(proxy.config.protocolPlugins.foo.config, proxy.context);
 
-        should(proxy.context.pluginStore.add)
-          .be.calledOnce()
-          .be.calledWith(pkg);
+        should(proxy.pluginStore.getByProtocol('protocol'))
+          .be.exactly(pkg);
       });
     });
 
     it('should log require errors and not fail', () => {
-      proxy.config.protocolPlugins = {
-        foo: {
-          activated: false,
-          config: {}
+      const
+        error = new Error('error'),
+        pkg = {
+          protocol: 'protocol',
+          init: sinon.spy()
         },
-        bar: {
-          activated: true,
-          config: {}
+        requireStub = sinon.stub();
+
+      requireStub.onFirstCall().returns(function () { return pkg; });
+      requireStub.onSecondCall().throws(error);
+
+      KuzzleProxy.__with__({
+        require: requireStub
+      })(() => {
+        proxy.config.protocolPlugins = {
+          foo: {
+            activated: true,
+            config: {}
+          },
+          bar: {
+            activated: true,
+            config: {}
+          }
+        };
+
+        proxy.initPlugins();
+
+        should(requireStub)
+          .be.calledTwice();
+
+        should(proxy.log.info)
+          .be.calledTwice()
+          .be.calledWith('Initializing protocol plugin foo')
+          .be.calledWith('Initializing protocol plugin bar');
+
+        should(proxy.log.error)
+          .be.calledOnce()
+          .be.calledWith('Initialization of plugin bar has failed; Reason: ');
+
+      });
+    });
+
+  });
+
+  describe('#initLogger', () => {
+    it('should support all available transports', () => {
+      proxy.config.logs.access = [{
+        level: 'level',
+        silent: 'silent',
+        colorize: 'colorize',
+        timestamp: 'timestamp',
+        json: 'json',
+        stringify: 'stringify',
+        prettyPrint: 'prettyPrint',
+        depth: 'depth',
+        showLevel: 'showLevel'
+      }];
+      proxy.config.logs.access.push(Object.assign({}, proxy.config.logs.access));
+      proxy.config.logs.errors = [Object.assign({}, proxy.config.logs.access)];
+      proxy.config.logs.errors.push(Object.assign({}, proxy.config.logs.access));
+
+      proxy.config.logs.access[0].transport = 'console';
+      proxy.config.logs.access[0].humanReadableUnhandledException = 'humanReadableUnhandledException';
+
+      proxy.config.logs.access[1].transport = 'file';
+      Object.assign(proxy.config.logs.access[1], {
+        filename: 'filename',
+        maxSize: 'maxSize',
+        maxFiles: 'maxFiles',
+        eol: 'eol',
+        logstash: 'logstash',
+        tailable: 'tailable',
+        maxRetries: 'maxRetries',
+        zippedArchive: 'zippedArchive'
+      });
+
+      proxy.config.logs.errors[0].transport = 'elasticsearch';
+      Object.assign(proxy.config.logs.errors[0], {
+        index: 'index',
+        indexPrefix: 'indexPrefix',
+        indexSuffixPattern: 'indexSuffixPattern',
+        messageType: 'messageType',
+        ensureMappingTemplate: 'ensureMappingTemplate',
+        mappingTemplate: 'mappingTemplate',
+        flushInterval: 'flushInterval',
+        clientOpts: 'clientOpts'
+      });
+
+      proxy.config.logs.errors[1].transport = 'syslog';
+      Object.assign(proxy.config.logs.errors[1], {
+        host: 'host',
+        port: 'port',
+        protocol: 'protocol',
+        path: 'path',
+        pid: 'pid',
+        facility: 'facility',
+        localhost: 'localhost',
+        type: 'type',
+        app_name: 'app_name',
+        eol: 'eol'
+      });
+
+      proxy.initLogger();
+
+      should(winstonTransportConsole)
+        .be.calledOnce()
+        .be.calledWithMatch({
+          level: 'level',
+          silent: 'silent',
+          colorize: 'colorize',
+          timestamp: 'timestamp',
+          json: 'json',
+          stringify: 'stringify',
+          prettyPrint: 'prettyPrint',
+          depth: 'depth',
+          showLevel: 'showLevel',
+          humanReadableUnhandledException: 'humanReadableUnhandledException'
+        });
+
+    });
+  });
+
+  describe('#logAccess', () => {
+    beforeEach(() => {
+      proxy.loggers = {
+        access: {
+          info: sinon.spy()
         }
-      };
-
-      proxy.initPlugins();
-
-      should(KuzzleProxy.__get__('console.log'))
-        .be.calledOnce()
-        .be.calledWith('Initializing protocol plugin bar');
-
-      should(KuzzleProxy.__get__('console.error'))
-        .be.calledOnce()
-        .be.calledWith('Initialization of plugin bar has failed; Reason: ');
+      }
     });
 
-    it('should fail if no plugin could be init', () => {
-      proxy.config.protocolPlugins = {};
-      proxy.context.pluginStore.count.returns(0);
+    it('should trigger an warn log if no connection could be found', () => {
+      proxy.logAccess(-1);
 
-      return should(() => proxy.initPlugins())
-        .throw('No plugin has been initialized properly. Shutting down.');
+      should(proxy.log.warn)
+        .be.calledOnce()
+        .be.calledWith('[access log] No connection retrieved for connection id: -1\n' +
+          'Most likely, the connection was closed before the response we received.');
+
+      should(proxy.loggers.access.info)
+        .have.callCount(0);
     });
+
+    it('should forward the params to the logger when using "logstash" format output', () => {
+      const
+        connection = { foo: 'bar' },
+        request = { foo: 'bar' },
+        error = { foo: 'bar' },
+        result = { foo: 'bar'};
+
+      proxy.clientConnectionStore.getByConnectionId = sinon.stub().returns(connection);
+      proxy.config.logs.accessLogFormat = 'logstash';
+
+      proxy.logAccess(connection, request, error, result);
+      should(proxy.loggers.access.info)
+        .be.calledOnce()
+        .be.calledWithMatch({
+          connection,
+          request,
+          error,
+          result
+      });
+    });
+
+    it('should output combined logs from an http request', () => {
+      const
+        connection = {
+          protocol: 'http',
+          headers: {
+            authorization: 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJfaWQiOiJhZG1pbiIsImlhdCI6MTQ4MjE3MDQwNywiZXhwIjoxNDgyMTg0ODA3fQ.SmLTFuIPsVuA8Pgpf9XONW2RtxcHjQffthNZ5Er4L4s',
+            referer: 'http://referer.com',
+            'user-agent': 'user agent'
+          },
+          ips: ['1.1.1.1', '2.2.2.2']
+        },
+        request = {
+          url: 'url',
+          method: 'METHOD'
+        },
+        result = {
+          status: 'status'
+        };
+
+      proxy.clientConnectionStore.getByConnectionId = sinon.stub().returns(connection);
+      proxy.config.logs.accessLogFormat = 'combined';
+      proxy.config.logs.accessLogIpOffset = 1;
+
+      proxy.logAccess(connection, request, null, result);
+
+      should(proxy.loggers.access.info)
+        .be.calledOnce()
+        .be.calledWithMatch(/^1.1.1.1 - admin \[\d\d\/[A-Z][a-z]{2}\/\d{4}:\d\d:\d\d:\d\d [+-]\d{4}] "METHOD url HTTP" status 19 "http:\/\/referer.com" "user agent"$/);
+    });
+
+    it('should use the error status in priority', () => {
+      const
+        connection = {
+          protocol: 'websocket',
+          headers: {
+            referer: 'http://referer.com',
+            'user-agent': 'user agent'
+          },
+          ips: ['1.1.1.1', '2.2.2.2']
+        },
+        request = {
+          data: {
+            timestamp: 'timestamp',
+            requestId: 'requestId',
+            jwt: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJfaWQiOiJhZG1pbiIsImlhdCI6MTQ4MjE3MDQwNywiZXhwIjoxNDgyMTg0ODA3fQ.SmLTFuIPsVuA8Pgpf9XONW2RtxcHjQffthNZ5Er4L4s',
+            controller: 'controller',
+            action: 'action',
+            index: 'index',
+            collection: 'collection',
+            _id: 'id'
+          }
+        },
+        error = new Error('test'),
+        result = {
+          status: 'status'
+        };
+
+      proxy.config.logs.accessLogFormat = 'combined';
+      proxy.clientConnectionStore.getByConnectionId = sinon.stub().returns(connection);
+
+      proxy.logAccess(1, request, error, result);
+      should(proxy.loggers.access.info)
+        .be.calledOnce()
+        .be.calledWithMatch(/^2.2.2.2 - admin \[\d\d\/[A-Z][a-z]{2}\/\d{4}:\d\d:\d\d:\d\d [+-]\d{4}] "DO \/controller\/action\/index\/collection\/id WEBSOCKET" 500 19 "http:\/\/referer.com" "user agent"/)
+
+      error.status = 'ERR';
+      proxy.logAccess(1, request, error, result);
+      should(proxy.loggers.access.info)
+        .be.calledTwice();
+      should(proxy.loggers.access.info.secondCall.args[0])
+        .match(/^2.2.2.2 - admin \[\d\d\/[A-Z][a-z]{2}\/\d{4}:\d\d:\d\d:\d\d [+-]\d{4}] "DO \/controller\/action\/index\/collection\/id WEBSOCKET" ERR 19 "http:\/\/referer.com" "user agent"/)
+    });
+
   });
 
-  describe('#initBroker', () => {
-    it('should init the broker', () => {
-      proxy.initBroker();
-
-      should(proxy.context.setBroker)
-        .be.calledOnce()
-        .be.calledWith(proxy.broker);
-
-      should(proxy.broker.init)
-        .be.calledOnce()
-        .be.calledWith(proxy.context, proxy.config.backend);
-    });
-  });
-
-  describe('#initHttpProxy', () => {
-    it('should init the http proxy', () => {
-      proxy.initHttpProxy();
-
-      should(proxy.httpProxy.init)
-        .be.calledOnce()
-        .be.calledWith(proxy.context, proxy.config);
-    });
-  });
 
 });

--- a/test/core/kuzzleProxy.test.js
+++ b/test/core/kuzzleProxy.test.js
@@ -333,10 +333,11 @@ describe('lib/core/KuzzleProxy', () => {
 
     it('should forward the params to the logger when using "logstash" format output', () => {
       const
-        connection = { foo: 'bar' },
-        request = { foo: 'bar' },
-        error = { foo: 'bar' },
-        result = { foo: 'bar'};
+        connection = {foo: 'bar' },
+        request = {foo: 'bar' },
+        error = new Error('test'),
+        result = {foo: 'bar', status: 'resultStatus'};
+      error.status = '444';
 
       proxy.clientConnectionStore.get = sinon.stub().returns(connection);
       proxy.config.logs.accessLogFormat = 'logstash';
@@ -347,8 +348,8 @@ describe('lib/core/KuzzleProxy', () => {
         .be.calledWithMatch({
           connection,
           request,
-          error,
-          result
+          error: 'Error: test',
+          status: '444'
         });
     });
 

--- a/test/service/backend.test.js
+++ b/test/service/backend.test.js
@@ -1,11 +1,9 @@
 var
   should = require('should'),
-  EventEmitter = require('events'),
   rewire = require('rewire'),
   Backend = rewire('../../lib/service/Backend'),
   sinon = require('sinon'),
-  PendingRequest = require.main.require('lib/store/PendingRequest'),
-  InternalError = require('kuzzle-common-objects').errors.InternalError;
+  PendingRequest = require.main.require('lib/store/PendingRequest');
 
 describe('service/Backend', () => {
   let
@@ -19,7 +17,7 @@ describe('service/Backend', () => {
         removeBackend: sinon.spy()
       },
       clientConnectionStore: {
-        getByConnectionId: sinon.stub()
+        get: sinon.stub()
       },
       log: {
         error: sinon.spy(),
@@ -79,7 +77,7 @@ describe('service/Backend', () => {
 
       should(proxy.log.error)
         .be.calledOnce()
-        .be.calledWith('Room is not specified in message: {}')
+        .be.calledWith('Room is not specified in message: {}');
     });
 
     it('should log an error if the room is unknonwn', () => {
@@ -89,7 +87,7 @@ describe('service/Backend', () => {
 
       should(proxy.log.error)
         .be.calledOnce()
-        .be.calledWith('Unknown message type idontexist')
+        .be.calledWith('Unknown message type idontexist');
     });
 
     it('should call the proper action', () => {
@@ -202,7 +200,7 @@ describe('service/Backend', () => {
         },
         error = new Error('test');
 
-      proxy.clientConnectionStore.getByConnectionId.returns({
+      proxy.clientConnectionStore.get.returns({
         protocol: 'protocol'
       });
       proxy.pluginStore.getByProtocol.returns({
@@ -221,7 +219,7 @@ describe('service/Backend', () => {
         connectionId: 'id'
       };
 
-      proxy.clientConnectionStore.getByConnectionId.returns({
+      proxy.clientConnectionStore.get.returns({
         protocol: 'protocol'
       });
       backend.onMessageRooms.joinChannel(data);
@@ -243,7 +241,7 @@ describe('service/Backend', () => {
         },
         error = new Error('test');
 
-      proxy.clientConnectionStore.getByConnectionId.returns({
+      proxy.clientConnectionStore.get.returns({
         protocol: 'protocol'
       });
       proxy.pluginStore.getByProtocol.throws(error);
@@ -260,7 +258,7 @@ describe('service/Backend', () => {
         connectionId: 'id'
       };
 
-      proxy.clientConnectionStore.getByConnectionId.returns({
+      proxy.clientConnectionStore.get.returns({
         protocol: 'protocol'
       });
 
@@ -278,7 +276,7 @@ describe('service/Backend', () => {
         },
         error = new Error('test');
 
-      proxy.clientConnectionStore.getByConnectionId.returns({
+      proxy.clientConnectionStore.get.returns({
         protocol: 'protocol'
       });
       proxy.pluginStore.getByProtocol.throws(error);
@@ -295,7 +293,7 @@ describe('service/Backend', () => {
         connectionId: 'id'
       };
 
-      proxy.clientConnectionStore.getByConnectionId.returns({
+      proxy.clientConnectionStore.get.returns({
         protocol: 'protocol'
       });
 
@@ -313,7 +311,7 @@ describe('service/Backend', () => {
         },
         error = new Error('test');
 
-      proxy.clientConnectionStore.getByConnectionId.returns({
+      proxy.clientConnectionStore.get.returns({
         protocol: 'protocol'
       });
       proxy.pluginStore.plugins = {
@@ -337,7 +335,7 @@ describe('service/Backend', () => {
         connectionId: 'id'
       };
 
-      proxy.clientConnectionStore.getByConnectionId.returns({
+      proxy.clientConnectionStore.get.returns({
         protocol: 'protocol'
       });
       proxy.pluginStore.plugins = {

--- a/test/service/backend.test.js
+++ b/test/service/backend.test.js
@@ -7,476 +7,359 @@ var
   PendingRequest = require.main.require('lib/store/PendingRequest'),
   InternalError = require('kuzzle-common-objects').errors.InternalError;
 
-describe('Test: service/Backend', function () {
-  var
-    sandbox,
-    dummyContext = {
-      dummy: 'context',
-      clientConnectionStore: {getByConnectionId: () => {}},
-      pluginStore: {getByProtocol: () => {}},
-      backendHandler: {removeBackend: () => {}}
-    },
-    dummyTimeout = 1234,
-    dummyAddress = 'aDummyAddress',
-    spyConsoleError,
-    spyConsoleLog,
-    spySocketClose;
-
-  before(() => {
-    sandbox = sinon.sandbox.create();
-  });
+describe('service/Backend', () => {
+  let
+    backend,
+    proxy,
+    socket;
 
   beforeEach(() => {
-    spySocketClose = sandbox.spy();
-    spyConsoleError = sandbox.spy();
-    spyConsoleLog = sandbox.spy();
-    Backend.__set__('console', {log: spyConsoleLog, error: spyConsoleError});
+    proxy = {
+      backendHandler: {
+        removeBackend: sinon.spy()
+      },
+      clientConnectionStore: {
+        getByConnectionId: sinon.stub()
+      },
+      log: {
+        error: sinon.spy(),
+        warn: sinon.spy()
+      },
+      pluginStore: {
+        getByProtocol: sinon.stub().returns({
+          joinChannel: sinon.spy(),
+          leaveChannel: sinon.spy(),
+          notify: sinon.spy()
+        })
+      }
+    };
+
+    socket = {
+      close: sinon.spy(),
+      on: sinon.spy(),
+      send: sinon.spy(),
+      upgradeReq: {
+        connection: {
+          remoteAddress: 'ip'
+        }
+      }
+    };
+
+    backend = new Backend(socket, proxy, 'timeout');
   });
 
   afterEach(() => {
-    sandbox.restore();
   });
 
-  it('method Constructor must initiate properly and plug good listeners to events', () => {
-    var
-      backend,
-      dummySocket = new EventEmitter(),
-      onConnectionCloseStub = sandbox.stub(Backend.prototype, 'onConnectionClose'),
-      onConnectionErrorStub = sandbox.stub(Backend.prototype, 'onConnectionError'),
-      onMessageStub = sandbox.stub(Backend.prototype, 'onMessage'),
-      messageRoomsStub = sandbox
-        .stub(Backend.prototype, 'initializeMessageRooms')
-        .returns({});
 
-    dummySocket.upgradeReq = {connection: {remoteAddress: dummyAddress}};
+  describe('#constructor', () => {
+    it('should init the request queue and attach events', () => {
+      should(backend.backendRequestStore)
+        .be.an.instanceOf(PendingRequest);
 
-    backend = new Backend(dummySocket, dummyContext, dummyTimeout);
-
-    backend.socket.emit('close');
-    backend.socket.emit('error');
-    backend.socket.emit('message');
-
-    should(onConnectionCloseStub.calledOnce).be.true();
-    should(onConnectionErrorStub.calledOnce).be.true();
-    should(messageRoomsStub.calledOnce).be.true();
-    should(onMessageStub.calledOnce).be.true();
-    should(backend.backendRequestStore).be.instanceOf(PendingRequest);
-    should(backend.onMessageRooms).be.an.Object();
+      should(socket.on)
+        .be.calledThrice()
+        .be.calledWith('close')
+        .be.calledWith('error')
+        .be.calledWith('message');
+    });
   });
 
   describe('#onMessage', () => {
-    it('must write a console error if the message contains no room', () => {
-      var
-        backend = initBackend(dummyContext),
-        badMessage = {no: 'room'},
-        badMessageString = JSON.stringify(badMessage);
+    it('should log an error if the message cannot be parsed', () => {
+      backend.onMessage('invalid json');
 
-      backend.onMessage(badMessageString);
-
-      should(spyConsoleError.calledWith(`Room is not specified in message: ${badMessageString}`)).be.true();
-    });
-
-    it('onMessage must write a console error if JSON.parse does not do what is expected', () => {
-      var
-        backend = initBackend(dummyContext),
-        badMessage = 'unexpected';
-
-      backend.onMessage(badMessage);
-
-      should(spyConsoleError)
+      should(proxy.log.error)
         .be.calledOnce()
-        .be.calledWithMatch('Bad message received from the backend : unexpected; Reason: SyntaxError: Unexpected token u');
+        .be.calledWithMatch(/^Bad message received from the backend: invalid json/);
     });
 
-    it('message room "response" must call the promise resolution if message is ok', () => {
-      var
-        backend = initBackend(dummyContext),
-        goodResponse = {room: 'response', data: {requestId: 'aRequestId', foo: 'aResponse'}},
-        goodResponseMessage = JSON.stringify(goodResponse),
-        resolveStub = sandbox.stub(backend.backendRequestStore, 'resolve');
+    it('should log an error if no room is given', () => {
+      backend.onMessage('{}');
 
-      backend.onMessage(goodResponseMessage);
-
-      should(resolveStub.calledOnce).be.true();
-      should(resolveStub.calledWith('aRequestId', null, goodResponse.data)).be.true();
+      should(proxy.log.error)
+        .be.calledOnce()
+        .be.calledWith('Room is not specified in message: {}')
     });
 
-    it('message room "httpResponse" must call the promise resolution if message is ok', () => {
-      var
-        backend = initBackend(dummyContext),
-        goodResponse = {
-          room: 'httpResponse',
-          data: {
-            requestId: 'aRequestId',
-            response: 'aResponse',
-            type: 'aType',
-            status: 'httpStatus'
-          }
+    it('should log an error if the room is unknonwn', () => {
+      backend.onMessage(JSON.stringify({
+        room: 'idontexist'
+      }));
+
+      should(proxy.log.error)
+        .be.calledOnce()
+        .be.calledWith('Unknown message type idontexist')
+    });
+
+    it('should call the proper action', () => {
+      backend.onMessageRooms.foo = sinon.spy();
+
+      backend.onMessage(JSON.stringify({
+        room: 'foo',
+        data: 'bar'
+      }));
+
+      should(backend.onMessageRooms.foo)
+        .be.calledOnce()
+        .be.calledWith('bar');
+    });
+  });
+
+  describe('#onConnectionClose', () => {
+    it('should remove the backend and abort all pending requests', () => {
+      backend.backendRequestStore.abortAll = sinon.spy();
+
+      backend.onConnectionClose();
+
+      should(proxy.backendHandler.removeBackend)
+        .be.calledOnce()
+        .be.calledWith(backend);
+
+      should(backend.backendRequestStore.abortAll)
+        .be.calledOnce();
+
+      should(socket.close)
+        .be.calledOnce();
+    });
+  });
+
+  describe('#onConnectionError', () => {
+    it('should remove the backend and abort all pending requests', () => {
+      const error = new Error('test');
+
+      backend.backendRequestStore.abortAll = sinon.spy();
+
+      backend.onConnectionError(error);
+
+      should(proxy.backendHandler.removeBackend)
+        .be.calledOnce()
+        .be.calledWith(backend);
+
+      should(backend.backendRequestStore.abortAll)
+        .be.calledOnce();
+    });
+  });
+
+  describe('#send', () => {
+    it('should register the cb and call the backend', () => {
+      backend.backendRequestStore.add = sinon.spy();
+
+      backend.send('room', 'id', 'data', 'callback');
+
+      should(backend.backendRequestStore.add)
+        .be.calledOnce()
+        .be.calledWith('id', 'data', 'callback');
+
+      should(socket.send)
+        .be.calledOnce()
+        .be.calledWith(JSON.stringify({room: 'room', data: 'data'}));
+    });
+  });
+
+  describe('#sendRaw', () => {
+    it('should forward the request to the backend socket', () => {
+      backend.sendRaw('room', 'data', 'callback');
+
+      should(socket.send)
+        .be.calledOnce()
+        .be.calledWith(JSON.stringify({room: 'room', data: 'data'}), 'callback');
+    });
+  });
+
+  describe('#room actions', () => {
+    beforeEach(() => {
+      backend.backendRequestStore.resolve = sinon.spy();
+    });
+
+    it('#response', () => {
+      const data = {
+        requestId: 'requestId'
+      };
+
+      backend.onMessageRooms.response(data);
+      should(backend.backendRequestStore.resolve)
+        .be.calledOnce()
+        .be.calledWith('requestId', null, data);
+    });
+
+    it('httpResponse', () => {
+      const data = {
+        requestId: 'requestId'
+      };
+
+      backend.onMessageRooms.httpResponse(data);
+
+      should(backend.backendRequestStore.resolve)
+        .be.calledOnce()
+        .be.calledWith('requestId', null, data);
+    });
+
+    it('#joinChannel should handle errors', () => {
+      const
+        data = {
+          connectionId: 'id'
         },
-        goodResponseMessage = JSON.stringify(goodResponse),
-        resolveStub = sandbox.stub(backend.backendRequestStore, 'resolve');
+        error = new Error('test');
 
-      backend.onMessage(goodResponseMessage);
+      proxy.clientConnectionStore.getByConnectionId.returns({
+        protocol: 'protocol'
+      });
+      proxy.pluginStore.getByProtocol.returns({
+        joinChannel: sinon.stub().throws(error)
+      });
 
-      should(resolveStub.calledOnce).be.true();
-      should(resolveStub.calledWithMatch('aRequestId', null, goodResponse.data)).be.true();
+      backend.onMessageRooms.joinChannel(data);
+
+      should(proxy.log.error)
+        .be.calledOnce()
+        .be.calledWith('[Join Channel] Plugin protocol failed: test');
     });
 
-    it('message room "joinChannel" must call joinChannel if everything is ok', () => {
-      var
-        backend = initBackend(dummyContext),
-        join = {room: 'joinChannel', data: {connectionId: 'anId', some: 'data'}},
-        joinMessage = JSON.stringify(join),
-        connectionGetStub,
-        pluginGetStub,
-        joinChannelSpy;
+    it('#joinChannel', () => {
+      const data = {
+        connectionId: 'id'
+      };
 
-      connectionGetStub = sandbox
-        .stub(backend.context.clientConnectionStore, 'getByConnectionId')
-        .returns({protocol: 'aType'});
+      proxy.clientConnectionStore.getByConnectionId.returns({
+        protocol: 'protocol'
+      });
+      backend.onMessageRooms.joinChannel(data);
 
-      joinChannelSpy = sandbox.spy();
+      should(proxy.pluginStore.getByProtocol)
+        .be.calledOnce()
+        .be.calledWith('protocol');
 
-      pluginGetStub = sandbox
-        .stub(backend.context.pluginStore, 'getByProtocol')
-        .returns({joinChannel: joinChannelSpy});
+      should(proxy.pluginStore.getByProtocol.firstCall.returnValue.joinChannel)
+        .be.calledOnce()
+        .be.calledWith(data);
 
-      backend.onMessage(joinMessage);
-
-      should(connectionGetStub.calledOnce).be.true();
-      should(connectionGetStub.calledWith('anId')).be.true();
-      should(pluginGetStub.calledOnce).be.true();
-      should(pluginGetStub.calledWith('aType')).be.true();
-      should(joinChannelSpy.calledOnce).be.true();
-      should(joinChannelSpy.calledWith(join.data)).be.true();
     });
 
-    it('message room "joinChannel" must do nothing if client type can not be determined', () => {
-      var
-        backend = initBackend(dummyContext),
-        join = {room: 'joinChannel', data: {connectionId: 'anId', some: 'data'}},
-        joinMessage = JSON.stringify(join),
-        connectionGetStub,
-        pluginGetStub;
+    it('#leaveChannel should log errors', () => {
+      const
+        data = {
+          connectionId: 'id'
+        },
+        error = new Error('test');
 
-      connectionGetStub = sandbox
-        .stub(backend.context.clientConnectionStore, 'getByConnectionId')
-        .returns({});
-      pluginGetStub = sandbox.stub(backend.context.pluginStore, 'getByProtocol');
+      proxy.clientConnectionStore.getByConnectionId.returns({
+        protocol: 'protocol'
+      });
+      proxy.pluginStore.getByProtocol.throws(error);
 
-      backend.onMessage(joinMessage);
+      backend.onMessageRooms.leaveChannel(data);
 
-      should(connectionGetStub.calledOnce).be.true();
-      should(connectionGetStub.calledWith('anId')).be.true();
-      should(pluginGetStub.callCount).be.eql(0);
+      should(proxy.log.error)
+        .be.calledOnce()
+        .be.calledWith('[Leave Channel] Plugin undefined failed: test');
     });
 
-    it('message room "joinChannel" should recover from a plugin crash', () => {
-      var
-        backend = initBackend(dummyContext),
-        join = {room: 'joinChannel', data: {connectionId: 'anId', some: 'data'}},
-        joinMessage = JSON.stringify(join),
-        connectionGetStub,
-        pluginGetStub,
-        joinChannelStub;
+    it('#leaveChannel', () => {
+      const data = {
+        connectionId: 'id'
+      };
 
-      connectionGetStub = sandbox
-        .stub(backend.context.clientConnectionStore, 'getByConnectionId')
-        .returns({protocol: 'aType'});
+      proxy.clientConnectionStore.getByConnectionId.returns({
+        protocol: 'protocol'
+      });
 
-      joinChannelStub = sandbox.stub();
-      joinChannelStub.throws(new Error('OH NOES!!1!'));
+      backend.onMessageRooms.leaveChannel(data);
 
-      pluginGetStub = sandbox
-        .stub(backend.context.pluginStore, 'getByProtocol')
-        .returns({joinChannel: joinChannelStub});
-
-      should.doesNotThrow(() => { backend.onMessage(joinMessage); });
-
-      should(connectionGetStub.calledOnce).be.true();
-      should(connectionGetStub.calledWith('anId')).be.true();
-      should(pluginGetStub.calledOnce).be.true();
-      should(pluginGetStub.calledWith('aType')).be.true();
-      should(joinChannelStub.calledOnce).be.true();
-      should(joinChannelStub.calledWith(join.data)).be.true();
+      should(proxy.pluginStore.getByProtocol.firstCall.returnValue.leaveChannel)
+        .be.calledOnce()
+        .be.calledWith(data);
     });
 
-    it('message room "leaveChannel" must call leaveChannel if everything is ok', () => {
-      var
-        backend = initBackend(dummyContext),
-        leave = {room: 'leaveChannel', data: {connectionId: 'anId', some: 'data'}},
-        leaveMessage = JSON.stringify(leave),
-        connectionGetStub,
-        pluginGetStub,
-        leaveChannelSpy;
+    it('#notify should log errors', () => {
+      const
+        data = {
+          connectionId: 'id'
+        },
+        error = new Error('test');
 
-      connectionGetStub = sandbox
-        .stub(backend.context.clientConnectionStore, 'getByConnectionId')
-        .returns({protocol: 'aType'});
+      proxy.clientConnectionStore.getByConnectionId.returns({
+        protocol: 'protocol'
+      });
+      proxy.pluginStore.getByProtocol.throws(error);
 
-      leaveChannelSpy = sandbox.spy();
+      backend.onMessageRooms.notify(data);
 
-      pluginGetStub = sandbox
-        .stub(backend.context.pluginStore, 'getByProtocol')
-        .returns({leaveChannel: leaveChannelSpy});
-
-      backend.onMessage(leaveMessage);
-
-      should(connectionGetStub.calledOnce).be.true();
-      should(connectionGetStub.calledWith('anId')).be.true();
-      should(pluginGetStub.calledOnce).be.true();
-      should(pluginGetStub.calledWith('aType')).be.true();
-      should(leaveChannelSpy.calledOnce).be.true();
-      should(leaveChannelSpy.calledWith(leave.data)).be.true();
+      should(proxy.log.error)
+        .be.calledOnce()
+        .be.calledWith('[Notify] Plugin protocol failed: test\nNotification data:\n%s');
     });
 
-    it('message room "leaveChannel" must do nothing if client type can not be determined', () => {
-      var
-        backend = initBackend(dummyContext),
-        leave = {room: 'leaveChannel', data: {connectionId: 'anId', some: 'data'}},
-        leaveMessage = JSON.stringify(leave),
-        connectionGetStub,
-        pluginGetStub;
+    it('#notify', () => {
+      const data = {
+        connectionId: 'id'
+      };
 
-      connectionGetStub = sandbox
-        .stub(backend.context.clientConnectionStore, 'getByConnectionId')
-        .returns({});
-      pluginGetStub = sandbox.stub(backend.context.pluginStore, 'getByProtocol');
+      proxy.clientConnectionStore.getByConnectionId.returns({
+        protocol: 'protocol'
+      });
 
-      backend.onMessage(leaveMessage);
+      backend.onMessageRooms.notify(data);
 
-      should(connectionGetStub.calledOnce).be.true();
-      should(connectionGetStub.calledWith('anId')).be.true();
-      should(pluginGetStub.callCount).be.eql(0);
+      should(proxy.pluginStore.getByProtocol.firstCall.returnValue.notify)
+        .be.calledOnce()
+        .be.calledWith(data);
     });
 
-    it('message room "leaveChannel" should recover from a plugin crash', () => {
-      var
-        backend = initBackend(dummyContext),
-        leave = {room: 'leaveChannel', data: {connectionId: 'anId', some: 'data'}},
-        leaveMessage = JSON.stringify(leave),
-        connectionGetStub,
-        pluginGetStub,
-        leaveChannelStub;
+    it('#broadcast should handle errors', () => {
+      const
+        data = {
+          connectionId: 'id'
+        },
+        error = new Error('test');
 
-      connectionGetStub = sandbox
-        .stub(backend.context.clientConnectionStore, 'getByConnectionId')
-        .returns({protocol: 'aType'});
+      proxy.clientConnectionStore.getByConnectionId.returns({
+        protocol: 'protocol'
+      });
+      proxy.pluginStore.plugins = {
+        foo: {
+          broadcast: sinon.spy()
+        },
+        bar: {
+          broadcast: sinon.stub().throws(error)
+        }
+      };
 
-      leaveChannelStub = sandbox.stub();
-      leaveChannelStub.throws(new Error('OH NOES!!1!'));
+      backend.onMessageRooms.broadcast(data);
 
-      pluginGetStub = sandbox
-        .stub(backend.context.pluginStore, 'getByProtocol')
-        .returns({leaveChannel: leaveChannelStub});
-
-      should.doesNotThrow(() => { backend.onMessage(leaveMessage); });
-
-      should(connectionGetStub.calledOnce).be.true();
-      should(connectionGetStub.calledWith('anId')).be.true();
-      should(pluginGetStub.calledOnce).be.true();
-      should(pluginGetStub.calledWith('aType')).be.true();
-      should(leaveChannelStub.calledOnce).be.true();
-      should(leaveChannelStub.calledWith(leave.data)).be.true();
+      should(proxy.log.error)
+        .be.calledOnce()
+        .be.calledWith('[Broadcast] Plugin undefined failed: test\nNotification data:\n%s');
     });
 
-    it('message room "notify" must call notify if everything is ok', () => {
-      var
-        backend = initBackend(dummyContext),
-        notify = {room: 'notify', data: {connectionId: 'anId', some: 'data'}},
-        notifyMessage = JSON.stringify(notify),
-        connectionGetStub,
-        pluginGetStub,
-        notifySpy;
+    it('#broadcast', () => {
+      const data = {
+        connectionId: 'id'
+      };
 
-      connectionGetStub = sandbox
-        .stub(backend.context.clientConnectionStore, 'getByConnectionId')
-        .returns({protocol: 'aType'});
+      proxy.clientConnectionStore.getByConnectionId.returns({
+        protocol: 'protocol'
+      });
+      proxy.pluginStore.plugins = {
+        foo: {
+          broadcast: sinon.spy()
+        },
+        bar: {
+          broadcast: sinon.spy()
+        }
+      };
 
-      notifySpy = sandbox.spy();
+      backend.onMessageRooms.broadcast(data);
 
-      pluginGetStub = sandbox
-        .stub(backend.context.pluginStore, 'getByProtocol')
-        .returns({notify: notifySpy});
-
-      backend.onMessage(notifyMessage);
-
-      should(connectionGetStub.calledOnce).be.true();
-      should(connectionGetStub.calledWith('anId')).be.true();
-      should(pluginGetStub.calledOnce).be.true();
-      should(pluginGetStub.calledWith('aType')).be.true();
-      should(notifySpy.calledOnce).be.true();
-      should(notifySpy.calledWith(notify.data)).be.true();
-    });
-
-    it('message room "notify" must do nothing if client type can not be determined', () => {
-      var
-        backend = initBackend(dummyContext),
-        notify = {room: 'notify', data: {connectionId: 'anId', some: 'data'}},
-        notifyMessage = JSON.stringify(notify),
-        connectionGetStub,
-        pluginGetStub;
-
-      connectionGetStub = sandbox
-        .stub(backend.context.clientConnectionStore, 'getByConnectionId')
-        .returns({});
-      pluginGetStub = sandbox.stub(backend.context.pluginStore, 'getByProtocol');
-
-      backend.onMessage(notifyMessage);
-
-      should(connectionGetStub.calledOnce).be.true();
-      should(connectionGetStub.calledWith('anId')).be.true();
-      should(pluginGetStub.callCount).be.eql(0);
-    });
-
-    it('message room "notify" must recover from a plugin crash', () => {
-      var
-        backend = initBackend(dummyContext),
-        notify = {room: 'notify', data: {connectionId: 'anId', some: 'data'}},
-        notifyMessage = JSON.stringify(notify),
-        connectionGetStub,
-        pluginGetStub,
-        notifyStub;
-
-      connectionGetStub = sandbox
-        .stub(backend.context.clientConnectionStore, 'getByConnectionId')
-        .returns({protocol: 'aType'});
-
-      notifyStub = sandbox.stub();
-      notifyStub.throws(new Error('OH NOES!!1!'));
-
-      pluginGetStub = sandbox
-        .stub(backend.context.pluginStore, 'getByProtocol')
-        .returns({notify: notifyStub});
-
-      should.doesNotThrow(() => { backend.onMessage(notifyMessage); });
-
-      should(connectionGetStub.calledOnce).be.true();
-      should(connectionGetStub.calledWith('anId')).be.true();
-      should(pluginGetStub.calledOnce).be.true();
-      should(pluginGetStub.calledWith('aType')).be.true();
-      should(notifyStub.calledOnce).be.true();
-      should(notifyStub.calledWith(notify.data)).be.true();
-    });
-
-    it('message room "broadcast" must broadcast message to all plugins', () => {
-      var
-        spyPluginBroadcast = sandbox.spy(),
-        pluginContext = {pluginStore: {plugins: {aPlugin: {broadcast: spyPluginBroadcast}}}},
-        backend = initBackend(pluginContext),
-        broadcast = {room: 'broadcast', data: {some: 'data'}},
-        broadcastMessage = JSON.stringify(broadcast);
-
-      backend.onMessage(broadcastMessage);
-
-      should(spyPluginBroadcast.calledOnce).be.true();
-      should(spyPluginBroadcast.calledWith(broadcast.data)).be.true();
-    });
-
-    it('message room "broadcast" must recover from a plugin crash', () => {
-      var
-        stubPluginBroadcast = sandbox.stub(),
-        pluginContext = {pluginStore: {plugins: {aPlugin: {broadcast: stubPluginBroadcast}}}},
-        backend = initBackend(pluginContext),
-        broadcast = {room: 'broadcast', data: {some: 'data'}},
-        broadcastMessage = JSON.stringify(broadcast);
-
-      stubPluginBroadcast.throws(new Error('OH NOES!!1!'));
-
-      should.doesNotThrow(() => {backend.onMessage(broadcastMessage); });
-
-      should(stubPluginBroadcast.calledOnce).be.true();
-      should(stubPluginBroadcast.calledWith(broadcast.data)).be.true();
-    });
-
-    it('unexpected message room should write a message in console error', () => {
-      var
-        backend = initBackend(dummyContext),
-        unexpected = {room: 'unexpected'},
-        unexpectedMessage = JSON.stringify(unexpected);
-
-      backend.onMessage(unexpectedMessage);
-
-      should(spyConsoleError.calledWith('Unknown message type unexpected')).be.true();
+      should(proxy.pluginStore.plugins.foo.broadcast)
+        .be.calledOnce()
+        .be.calledWith(data);
+      should(proxy.pluginStore.plugins.bar.broadcast)
+        .be.calledOnce()
+        .be.calledWith(data);
     });
   });
 
-  it('#onConnectionClose', () => {
-    var
-      backend = initBackend(dummyContext),
-      abortAllStub = sandbox.stub(backend.backendRequestStore, 'abortAll'),
-      removeBackendStub = sandbox.stub(backend.context.backendHandler, 'removeBackend');
-
-    backend.onConnectionClose();
-
-    should(spyConsoleLog.calledOnce).be.true();
-    should(spyConsoleLog.calledWith(`Connection with backend ${dummyAddress} closed.`)).be.true();
-    should(spySocketClose.calledOnce).be.true();
-    should(abortAllStub.calledOnce).be.true();
-    should(abortAllStub.calledWithMatch(InternalError));
-    should(removeBackendStub.calledOnce).be.true();
-    should(removeBackendStub.calledWith(backend)).be.true();
-  });
-
-  it('#onConnectionError', () => {
-    var
-      backend = initBackend(dummyContext),
-      abortAllStub = sandbox.stub(backend.backendRequestStore, 'abortAll'),
-      removeBackendStub,
-      error = new Error('an Error');
-
-    removeBackendStub = sandbox.stub(backend.context.backendHandler, 'removeBackend');
-
-    backend.onConnectionError(error);
-
-    should(spyConsoleError.calledOnce).be.true();
-    should(spyConsoleError.calledWith(`Connection error with backend ${dummyAddress}; Reason:`, error)).be.true();
-    should(abortAllStub.calledOnce).be.true();
-    should(abortAllStub.calledWithMatch(InternalError));
-    should(removeBackendStub.calledOnce).be.true();
-    should(removeBackendStub.calledWith(backend)).be.true();
-  });
-
-
-  it('#send', () => {
-    var
-      backend = initBackend(dummyContext),
-      addStub = sandbox.stub(backend.backendRequestStore, 'add'),
-      data = {message: 'a message'},
-      id = 'id',
-      cb = function () {},
-      room = 'room';
-
-    backend.socket.send = sandbox.stub();
-
-    backend.send(room, id, data, cb);
-
-    should(addStub.calledOnce).be.true();
-    should(addStub.calledWith(id, data, cb)).be.true();
-    should(backend.socket.send.calledOnce).be.true();
-    should(backend.socket.send.calledWith(JSON.stringify({room, data}))).be.true();
-  });
-
-  function initBackend (context) {
-    var dummySocket = new EventEmitter();
-
-    dummySocket.close = spySocketClose;
-    dummySocket.upgradeReq = {connection: {remoteAddress: dummyAddress}};
-
-    return new Backend(dummySocket, context, dummyTimeout);
-  }
-
-  it('#sendRaw', () => {
-    var
-      backend = initBackend(dummyContext),
-      cb = () => {},
-      message = 'foobar';
-
-    backend.socket.send = sandbox.spy();
-
-    backend.sendRaw(message, cb);
-
-    should(backend.socket.send.calledOnce).be.true();
-    should(backend.socket.send.calledWith(message, cb));
-  });
 });
+
+

--- a/test/service/httpProxy.test.js
+++ b/test/service/httpProxy.test.js
@@ -226,7 +226,7 @@ describe('/service/httpProxy', () => {
 
       should(response.end)
         .be.calledOnce()
-        .be.calledWith(JSON.stringify(result, undefined, 2));
+        .be.calledWith(JSON.stringify(result.content, undefined, 2));
     });
 
     it('should output buffer raw result', () => {

--- a/test/service/router.test.js
+++ b/test/service/router.test.js
@@ -5,169 +5,133 @@ const
   sinon = require('sinon'),
   rewire = require('rewire'),
   Router = rewire('../../lib/service/Router'),
-  RequestContext = require('kuzzle-common-objects').models.RequestContext,
-  Request = require('kuzzle-common-objects').Request,
-  InternalError = require('kuzzle-common-objects').errors.InternalError,
   ServiceUnavailableError = require('kuzzle-common-objects').errors.ServiceUnavailableError;
 
 describe('#Test: service/Router', function () {
   let
     sandbox,
-    dummyProtocol = 'a protocol',
-    dummySocketId = 'a socket id';
+    proxy,
+    router;
 
   before(() => {
     sandbox = sinon.sandbox.create();
   });
 
   beforeEach(() => {
+    proxy = {
+      backendHandler: {
+        getBackend: sinon.stub().returns({})
+      },
+      broker: {
+        addClientConnection: sinon.spy(),
+        brokerCallback: sinon.spy(),
+        removeClientConnection: sinon.spy()
+      },
+      clientConnectionStore: {
+        get: sinon.stub()
+      }
+    };
+
+    router = new Router(proxy);
   });
 
   afterEach(() => {
     sandbox.restore();
   });
 
-  it('method constructor initializes the object properly', () => {
-    let
-      dummyContext = {dummy: 'context'},
-      router = new Router(dummyContext);
-
-    should(router.context).be.deepEqual(dummyContext);
+  describe('#constructor', () => {
+    it('method constructor initializes the object properly', () => {
+      should(Router.__get__('_proxy'))
+        .be.exactly(proxy);
+    });
   });
 
-  it('method newConnection must add an unknown client', (done) => {
-    let
-      dummyContext = {
-        clientConnectionStore: {get: sandbox.stub().returns({type: 'another protocol'})},
-        broker: {addClientConnection: sandbox.stub()},
-        backendHandler: {getBackend: sandbox.stub().returns('foobar')}
-      },
-      router = new Router(dummyContext),
-      expectedConnection = new RequestContext({connectionId: dummySocketId, protocol: dummyProtocol});
+  describe('#newConnection', () => {
+    it('should throw if no backend is available', () => {
+      proxy.backendHandler.getBackend.returns(undefined);
 
-    router.newConnection(dummyProtocol, dummySocketId)
-      .then((connection) => {
-        should(dummyContext.clientConnectionStore.get.calledOnce).be.true();
-        should(dummyContext.clientConnectionStore.get.calledWithMatch(expectedConnection)).be.true();
-        should(dummyContext.broker.addClientConnection.calledOnce).be.true();
-        should(dummyContext.broker.addClientConnection.calledWithMatch(expectedConnection)).be.true();
-        should(connection).be.deepEqual(expectedConnection);
-        done();
-      })
-      .catch(e => done(e));
+      return should(() => router.newConnection({}))
+        .throw(ServiceUnavailableError, {message: 'No Kuzzle instance found'});
+    });
+
+    it('should add the connection to the backend', () => {
+      router.newConnection('connection');
+
+      should(proxy.broker.addClientConnection)
+        .be.calledOnce()
+        .be.calledWith('connection');
+    });
+
   });
 
-  it('method newConnection must not add a known client', (done) => {
+  describe('#execute', () => {
     let
-      dummyContext = {
-        clientConnectionStore: {get: sandbox.stub().returns({protocol: dummyProtocol})},
-        broker: {addClientConnection: sandbox.stub()},
-        backendHandler: {getBackend: sandbox.stub().returns('foobar')}
-      },
-      router = new Router(dummyContext),
-      expectedConnection = new RequestContext({connectionId: dummySocketId, protocol: dummyProtocol});
+      request;
 
-    router.newConnection(dummyProtocol, dummySocketId)
-      .then((connection) => {
-        should(dummyContext.clientConnectionStore.get.calledOnce).be.true();
-        should(dummyContext.clientConnectionStore.get.calledWith(expectedConnection)).be.true();
-        should(dummyContext.broker.addClientConnection.callCount).be.eql(0);
-        should(connection).be.deepEqual(expectedConnection);
-        done();
-      })
-      .catch(e => done(e));
+    beforeEach(() => {
+      request = {
+        id: 'requestId',
+        context: {
+          connectionId: 'connectionId'
+        },
+        response: 'response',
+        serialize: sinon.stub().returns('serializedRequest'),
+        setError: sinon.spy()
+      };
+    });
+
+    it('should call the broker callback with a cb that properly handles errors back from Kuzzle', () => {
+      const
+        cb = sinon.spy(),
+        error = new Error('test');
+
+      router.execute(request, cb);
+
+      should(proxy.broker.brokerCallback)
+        .be.calledOnce()
+        .be.calledWith('request', request.id, request.context.connectionId, 'serializedRequest');
+
+      const brokerCb = proxy.broker.brokerCallback.firstCall.args[4];
+
+      brokerCb(error);
+
+      should(request.setError)
+        .be.calledOnce()
+        .be.calledWith(error);
+
+      should(cb)
+        .be.calledOnce()
+        .be.calledWith('response');
+    });
+
+    it('should call the broker callback with a cb that handles success', () => {
+      const
+        cb = sinon.spy();
+
+      router.execute(request, cb);
+
+      const brokerCb = proxy.broker.brokerCallback.firstCall.args[4];
+
+      brokerCb(undefined, 'result');
+
+      should(cb)
+        .be.calledOnce()
+        .be.calledWith('result');
+    });
   });
 
-  it('method newConnection should reject the promise if no backend is available', () => {
-    let
-      dummyContext = {
-        backendHandler: {getBackend: sandbox.stub().returns(null)}
-      },
-      router = new Router(dummyContext);
+  describe('#removeConnection', () => {
+    it('should remove the conection from the broker', () => {
+      const connection = {foo: 'bar'};
 
-    return should(router.newConnection(dummyProtocol, dummySocketId)).be.rejectedWith(ServiceUnavailableError);
-  });
+      proxy.clientConnectionStore.get.returns(connection);
 
-  it('method execute calls the broker properly and resolves to the response', (done) => {
-    let
-      dummyContext = {
-        broker: {
-          brokerCallback: sandbox.spy((room, id, message, callback) => callback(null, message))
-        }
-      },
-      router = new Router(dummyContext),
-      dummyRequest = new Request({}),
-      callbackSpy = sandbox.spy(response => {
-        should(callbackSpy.calledOnce).be.true();
-        should(dummyContext.broker.brokerCallback.calledOnce).be.true();
-        should(dummyContext.broker.brokerCallback.args[0][0]).be.eql('request');
-        should(dummyContext.broker.brokerCallback.args[0][1]).be.eql(dummyRequest.id);
-        should(dummyContext.broker.brokerCallback.args[0][2]).be.eql(dummyRequest.serialize());
-        should(response).be.eql(dummyRequest.serialize());
+      router.removeConnection('id');
 
-        done();
-      });
+      should(proxy.broker.removeClientConnection)
+        .be.calledOnce()
+        .be.calledWith(connection);
+    });
 
-    router.execute(dummyRequest, callbackSpy);
-  });
-
-  it('method execute calls the broker properly and if an error occurs, resolves to an error response', (done) => {
-    let
-      dummyError = new Error('an Error'),
-      dummyContext = {
-        broker: {
-          brokerCallback: sandbox.spy((room, id, message, callback) => callback(dummyError))
-        }
-      },
-      router = new Router(dummyContext),
-      dummyRequest = new Request({}),
-      callbackSpy = sandbox.spy(response => {
-        should(callbackSpy.calledOnce).be.true();
-        should(dummyContext.broker.brokerCallback.calledOnce).be.true();
-        should(dummyContext.broker.brokerCallback.args[0][0]).be.eql('request');
-        should(dummyContext.broker.brokerCallback.args[0][1]).be.eql(dummyRequest.id);
-        should(dummyContext.broker.brokerCallback.args[0][2]).match(dummyError);
-        should(response.error).be.instanceOf(InternalError);
-        should(response.error.message).be.eql(dummyError.message);
-        should(response.status).be.eql(500);
-        should(response.result).be.null();
-
-        done();
-      });
-
-    router.execute(dummyRequest, callbackSpy);
-  });
-
-  it('method removeConnection removes a client connection if it is present', () => {
-    let
-      dummyContext = {
-        broker: {removeClientConnection: sandbox.spy()},
-        clientConnectionStore: {get: sandbox.stub().returns(true)}
-      },
-      router = new Router(dummyContext),
-      dummyConnection = {id: 'dummy'};
-
-    router.removeConnection(dummyConnection);
-
-    should(dummyContext.clientConnectionStore.get.calledOnce).be.true();
-    should(dummyContext.clientConnectionStore.get.calledWith(dummyConnection)).be.true();
-    should(dummyContext.broker.removeClientConnection.calledOnce).be.true();
-    should(dummyContext.broker.removeClientConnection.calledWith(dummyConnection)).be.true();
-  });
-
-  it('method removeConnection removes a client connection if it is present', () => {
-    let
-      dummyContext = {
-        broker: {removeClientConnection: sandbox.spy()},
-        clientConnectionStore: {get: sandbox.stub().returns(false)}
-      },
-      router = new Router(dummyContext),
-      dummyConnection = {id: 'dummy'};
-
-    router.removeConnection(dummyConnection);
-
-    should(dummyContext.clientConnectionStore.get.calledOnce).be.true();
-    should(dummyContext.clientConnectionStore.get.calledWith(dummyConnection)).be.true();
-    should(dummyContext.broker.removeClientConnection.callCount).be.eql(0);
   });
 });

--- a/test/store/clientConnection.test.js
+++ b/test/store/clientConnection.test.js
@@ -2,112 +2,71 @@
 
 const
   should = require('should'),
-  RequestContext = require('kuzzle-common-objects').models.RequestContext,
-  ClientConnection = require.main.require('lib/store/ClientConnection');
+  ClientConnection = require('../../lib/store/ClientConnection');
 
-describe('Test: store/ClientConnection', function () {
-  var
-    dummyConnectionExist = new RequestContext({connectionId: 'exists', protocol: 'dummy'}),
-    dummyConnectionDoesNotExist = new RequestContext({connectionId: 'doesnotexist', protocol: 'dummy'}),
-    dummyInvalidConnection = new RequestContext({foo: 'invalid', protocol: 'dummy'});
+describe('store/clientConnection', () => {
+  let
+    store;
 
-  it('constructor must initialize clientConnections', () => {
-    var clientConnection = new ClientConnection();
-
-    should(clientConnection.clientConnections).be.an.Object();
+  beforeEach(() => {
+    store = new ClientConnection();
   });
 
-  it('method add must add an item to the clientConnections', () => {
-    var clientConnection = new ClientConnection();
+  describe('#add', () => {
+    it('should add a new connection', () => {
+      const connection = {id: 'connectionId'};
+      store.add(connection);
 
-    clientConnection.add(dummyConnectionExist);
-
-    should(clientConnection.clientConnections[dummyConnectionExist.connectionId]).be.deepEqual(dummyConnectionExist);
+      should(store.clientConnections.connectionId)
+        .be.exactly(connection);
+    });
   });
 
-  it('method add must not add an item to the clientConnections if invalid', () => {
-    var clientConnection = new ClientConnection();
+  describe('#remove', () => {
+    it('should do nothing is the connection is unknown', () => {
+      store.clientConnections.id = {foo: 'bar'};
+      store.remove('wrong id');
 
-    clientConnection.add(dummyInvalidConnection);
+      should(Object.keys(store.clientConnections))
+        .have.length(1);
+    });
 
-    should(Object.keys(clientConnection.clientConnections).length).be.eql(0);
+    it('should remove the conneciton', () => {
+      store.clientConnections.id = {foo: 'bar'};
+      store.remove('id');
+
+      should(store.clientConnections)
+        .be.empty();
+    });
   });
 
-  it('method remove must remove an item from the clientConnections if it exists', () => {
-    var clientConnection = new ClientConnection();
+  describe('#get', () => {
+    it('should, given a connection Id, return the matching connection', () => {
+      const connection = {foo: 'bar'};
+      store.clientConnections.id = connection;
 
-    clientConnection.clientConnections = {[dummyConnectionExist.connectionId]: dummyConnectionExist};
+      should(store.get('id'))
+        .be.exactly(connection);
+    });
 
-    clientConnection.remove(dummyConnectionExist);
-
-    should(Object.keys(clientConnection.clientConnections).length).be.eql(0);
+    it('should return undefined if the given id does not match any connection in the store', () => {
+      should(store.get('id'))
+        .be.undefined();
+    });
   });
 
-  it('method remove must not remove an item from the clientConnections if it does not exist', () => {
-    var clientConnection = new ClientConnection();
+  describe('#getAll', () => {
+    it('should return the store connections as an array', () => {
+      store.clientConnections.foo = 'bar';
+      store.clientConnections.bar = 'baz';
+      store.clientConnections.blah = 'blah';
 
-    clientConnection.clientConnections = {[dummyConnectionExist.connectionId]: dummyConnectionExist};
-
-    clientConnection.remove(dummyConnectionDoesNotExist);
-
-    should(Object.keys(clientConnection.clientConnections).length).be.eql(1);
-  });
-
-  it('method remove must not remove an item from the clientConnections if argument is invalid', () => {
-    var clientConnection = new ClientConnection();
-
-    clientConnection.clientConnections = {[dummyConnectionExist.connectionId]: dummyConnectionExist};
-
-    clientConnection.remove(dummyInvalidConnection);
-
-    should(Object.keys(clientConnection.clientConnections).length).be.eql(1);
-  });
-
-  it('method get must return an item from clientConnections if it exists', () => {
-    var clientConnection = new ClientConnection();
-
-    clientConnection.clientConnections = {[dummyConnectionExist.connectionId]: dummyConnectionExist};
-
-    should(clientConnection.get(dummyConnectionExist)).be.deepEqual(dummyConnectionExist);
-  });
-
-  it('method get must return undefined if the item does not exist in clientConnections', () => {
-    var clientConnection = new ClientConnection();
-
-    clientConnection.clientConnections = {[dummyConnectionExist.connectionId]: dummyConnectionExist};
-
-    should(clientConnection.get(dummyConnectionDoesNotExist)).be.undefined();
-  });
-
-  it('method get must return undefined if the argument is invalid', () => {
-    var clientConnection = new ClientConnection();
-
-    clientConnection.clientConnections = {[dummyConnectionExist.connectionId]: dummyConnectionExist};
-
-    should(clientConnection.get(dummyInvalidConnection)).be.undefined();
-  });
-
-  it('method getByConnectionId must return an item from clientConnections if it exists', () => {
-    var clientConnection = new ClientConnection();
-
-    clientConnection.clientConnections = {[dummyConnectionExist.connectionId]: dummyConnectionExist};
-
-    should(clientConnection.getByConnectionId(dummyConnectionExist.connectionId)).be.deepEqual(dummyConnectionExist);
-  });
-
-  it('method get must return undefined if the item doesn\'t not exist in clientConnections', () => {
-    var clientConnection = new ClientConnection();
-
-    clientConnection.clientConnections = {[dummyConnectionExist.connectionId]: dummyConnectionExist};
-
-    should(clientConnection.getByConnectionId(dummyConnectionDoesNotExist.connectionId)).be.undefined();
-  });
-
-  it('method getAll must return clientConnections', () => {
-    var clientConnection = new ClientConnection();
-
-    clientConnection.clientConnections = {[dummyConnectionExist.connectionId]: dummyConnectionExist};
-
-    should(clientConnection.getAll()).be.deepEqual(clientConnection.clientConnections);
+      should(store.getAll())
+        .match([
+          'bar',
+          'baz',
+          'blah'
+        ]);
+    });
   });
 });


### PR DESCRIPTION
cf #39 

# Loggers

* 2 loggers ([winston](https://github.com/winstonjs/winston)) are injected in the Proxy, each having its own configuration:
  1. One dedicated to access logs
  2. One dedicated to other (errors) logs
* All `console.log` and `console.error` calls are removed and use the error logger instead.
* Default configuration is to output logs to the terminal. Access logs are sent to stdout, ~~error logs are sent to stderr.~~ [EDIT: error logs levels `warn`, `error` and `debug` are sent to stderr, other levels are output to stdout.]
* Currently supported transports are `console`, `file`, `elasticsearch` and `syslog`.

## Access logs output format

For the time being, 2 output formats are supported: `logstash` and `combined`. 
The `logstash` format outputs the data in json, ready to use by logstash (or by elasticsearch transport).
The `combined` format mimics [Apache combined](http://httpd.apache.org/docs/current/logs.html#combined) format.

Main differences are:

* The user data is taken from the jwt token when available with a fall back to Basic auth
* For non-http protocols, the URL is rebuilt based on the request data: `/controller/action/index/collection/_id?additional-param=1&additional-param=2`. The verb for such cases is always set to `DO` and the protocol is the one take from the connection, uppercased (i.e., `WEBSOCKET` or `MQTT`.

## unrelated / boyscooting

While not directly linked to this PR, the context object passed to the protocol plugins is cleaned up to its strict minimal form.
This object was previously used to store the global scope of the proxy application. Loggers had to be included in this scope but there was no reason the protocol plugins could access the access log, thus this little refactor.

All the components of the proxy that previously relied on the context now use a complete proxy instance.


@dependencies / @todo
* https://github.com/kuzzleio/kuzzle-common-objects/pull/14
* https://github.com/kuzzleio/kuzzle/pull/595
* https://github.com/kuzzleio/kuzzle-plugin-websocket/pull/12
* https://github.com/kuzzleio/kuzzle-plugin-socketio/pull/14
* https://github.com/kuzzleio/kuzzle-plugin-mqtt/pull/8
* https://github.com/kuzzleio/kuzzle-load-balancer