### PR TITLE
Http multipart/form-data support to enable file uploads

### DIFF
--- a/.proxyrc.sample
+++ b/.proxyrc.sample
@@ -47,6 +47,9 @@
   //   maxRequestSize: the size limit of a request. If it's a string, the
   //       value is passed to the "bytes" library (https://www.npmjs.com/package/bytes).
   //       If this is a number, then the value specifies the number of bytes.
+  //   maxFileSize: the size limit of a file (for upload requests). If it's a string, the
+  //       value is passed to the "bytes" library (https://www.npmjs.com/package/bytes).
+  //       If this is a number, then the value specifies the number of bytes.
   //   [host]:  ip on which the proxy should bind itself for http connections. Defaults to all interfaces
   "http": {
     "port": 7511,

--- a/.proxyrc.sample
+++ b/.proxyrc.sample
@@ -50,6 +50,7 @@
   //   [host]:  ip on which the proxy should bind itself for http connections. Defaults to all interfaces
   "http": {
     "port": 7511,
-    "maxRequestSize": "1MB"
+    "maxRequestSize": "1MB",
+    "maxFileSize": "1MB"
   }
 }

--- a/lib/core/config.js
+++ b/lib/core/config.js
@@ -57,7 +57,8 @@ config = rc('proxy', {
   },
   http: {
     port: 7511,
-    maxRequestSize: '1MB'
+    maxRequestSize: '1MB',
+    maxFileSize: '1MB'
   }
 });
 

--- a/lib/service/HttpFormDataStream.js
+++ b/lib/service/HttpFormDataStream.js
@@ -2,6 +2,7 @@
 
 const
   inherits = require('util').inherits,
+  SizeLimitError = require('kuzzle-common-objects').errors.SizeLimitError,
   Busboy = require('busboy');
 
 
@@ -12,7 +13,7 @@ const
  * @param {Object} payload
  * @param {Function} throwSizeLimitError
  */
-function HttpFormDataStream (opts, payload, throwSizeLimitError) {
+function HttpFormDataStream (opts, payload) {
   Busboy.call(this, opts);
   payload.json = {};
 
@@ -24,8 +25,10 @@ function HttpFormDataStream (opts, payload, throwSizeLimitError) {
     });
 
     file.on('limit', () => {
-      this.end();
-      throwSizeLimitError();
+      file
+        .removeAllListeners()
+        .resume();
+      this.emit('error', new SizeLimitError('Error: maximum HTTP file size exceeded'));
     });
 
     file.on('end', () => {

--- a/lib/service/HttpFormDataStream.js
+++ b/lib/service/HttpFormDataStream.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const
+  inherits = require('util').inherits,
+  Busboy = require('busboy');
+
+
+/**
+ * @returns {HttpFormDataStream}
+ * @constructor
+ * @param {Object} opts
+ * @param {Object} payload
+ */
+function HttpFormDataStream (opts, payload) {
+  Busboy.call(this, opts);
+  this.content = {};
+
+  this.on('file', (fieldname, file, filename, encoding, mimetype) => {
+    let fileBuffer = Buffer.from('');
+
+    file.on('data', chunk => {
+      fileBuffer = Buffer.concat([fileBuffer, chunk], fileBuffer.length + chunk.length);
+    });
+
+    file.on('end', () => {
+      this.content[fieldname] = {
+        filename: filename,
+        encoding: encoding,
+        mimetype: mimetype,
+        file: fileBuffer.toString('base64')
+      };
+    });
+
+  });
+
+  this.on('field', (fieldname, val) => {
+    this.content[fieldname] = val;
+  });
+
+  this.on('end', () => {
+    payload.content = JSON.stringify(this.content);
+  });
+
+  return this;
+}
+
+inherits(HttpFormDataStream, Busboy);
+
+module.exports = HttpFormDataStream;

--- a/lib/service/HttpFormDataStream.js
+++ b/lib/service/HttpFormDataStream.js
@@ -14,7 +14,7 @@ const
  */
 function HttpFormDataStream (opts, payload, throwSizeLimitError) {
   Busboy.call(this, opts);
-  this.content = {};
+  payload.json = {};
 
   this.on('file', (fieldname, file, filename, encoding, mimetype) => {
     let fileBuffer = Buffer.from('');
@@ -28,7 +28,7 @@ function HttpFormDataStream (opts, payload, throwSizeLimitError) {
     });
 
     file.on('end', () => {
-      this.content[fieldname] = {
+      payload.json[fieldname] = {
         filename: filename,
         encoding: encoding,
         mimetype: mimetype,
@@ -39,11 +39,7 @@ function HttpFormDataStream (opts, payload, throwSizeLimitError) {
   });
 
   this.on('field', (fieldname, val) => {
-    this.content[fieldname] = val;
-  });
-
-  this.on('end', () => {
-    payload.content = JSON.stringify(this.content);
+    payload.json[fieldname] = val;
   });
 
   return this;

--- a/lib/service/HttpFormDataStream.js
+++ b/lib/service/HttpFormDataStream.js
@@ -11,7 +11,6 @@ const
  * @constructor
  * @param {Object} opts
  * @param {Object} payload
- * @param {Function} throwSizeLimitError
  */
 function HttpFormDataStream (opts, payload) {
   Busboy.call(this, opts);

--- a/lib/service/HttpFormDataStream.js
+++ b/lib/service/HttpFormDataStream.js
@@ -10,8 +10,9 @@ const
  * @constructor
  * @param {Object} opts
  * @param {Object} payload
+ * @param {Function} throwSizeLimitError
  */
-function HttpFormDataStream (opts, payload) {
+function HttpFormDataStream (opts, payload, throwSizeLimitError) {
   Busboy.call(this, opts);
   this.content = {};
 
@@ -20,6 +21,10 @@ function HttpFormDataStream (opts, payload) {
 
     file.on('data', chunk => {
       fileBuffer = Buffer.concat([fileBuffer, chunk], fileBuffer.length + chunk.length);
+    });
+
+    file.on('limit', () => {
+      throwSizeLimitError();
     });
 
     file.on('end', () => {

--- a/lib/service/HttpFormDataStream.js
+++ b/lib/service/HttpFormDataStream.js
@@ -24,6 +24,7 @@ function HttpFormDataStream (opts, payload, throwSizeLimitError) {
     });
 
     file.on('limit', () => {
+      this.end();
       throwSizeLimitError();
     });
 

--- a/lib/service/HttpProxy.js
+++ b/lib/service/HttpProxy.js
@@ -132,6 +132,11 @@ HttpProxy.prototype.init = function (proxy) {
  * @param {Object} payload
  */
 function sendRequest (connectionId, response, payload) {
+  if (payload.json) {
+    payload.content = JSON.stringify(payload.json);
+    delete payload.json;
+  }
+
   _proxy.broker.brokerCallback(KuzzleRoom, payload.requestId, connectionId, payload, (error, result) => {
     if (result) {
       _proxy.clientConnectionStore.remove(connectionId);

--- a/lib/service/HttpProxy.js
+++ b/lib/service/HttpProxy.js
@@ -109,6 +109,7 @@ HttpProxy.prototype.init = function (proxy) {
        * max size limit while reading the stream too
        */
       if (stream_length > this.maxRequestSize) {
+        stream.end();
         return throwSizeLimitError();
       }
       stream.write(chunk);

--- a/lib/service/HttpProxy.js
+++ b/lib/service/HttpProxy.js
@@ -7,6 +7,7 @@ const
   url = require('url'),
   SizeLimitError = require('kuzzle-common-objects').errors.SizeLimitError,
   Writable = require('stream').Writable,
+  HttpFormDataStream = require('./HttpFormDataStream'),
   KuzzleRoom = 'httpRequest';
 
 /**
@@ -38,12 +39,7 @@ HttpProxy.prototype.init = function (context, config) {
 
   this.server = http.createServer((request, response) => {
     let
-      stream = new Writable({
-        write(chunk, encoding, callback) {
-          payload.content += chunk.toString();
-          callback();
-        }
-      }),
+      stream,
       stream_length = 0,
       payload = {
         requestId: uuid.v4(),
@@ -56,6 +52,17 @@ HttpProxy.prototype.init = function (context, config) {
     if (request.headers['content-length'] > this.maxRequestSize) {
       request.resume();
       return replyWithError(response, new SizeLimitError('Error: maximum HTTP request size exceeded'));
+    }
+
+    if (!request.headers['content-type'] || request.headers['content-type'].startsWith('application/json')) {
+      stream = new Writable({
+        write(chunk, encoding, callback) {
+          payload.content += chunk.toString();
+          callback();
+        }
+      });
+    } else {
+      stream = new HttpFormDataStream({headers: request.headers}, payload);
     }
 
     request.on('data', chunk => {
@@ -77,6 +84,8 @@ HttpProxy.prototype.init = function (context, config) {
     });
 
     request.on('end', () => {
+      payload.headers['content-type'] = 'application/json';
+      stream.emit('end');
       sendRequest(context, response, payload);
     });
   });

--- a/lib/service/HttpProxy.js
+++ b/lib/service/HttpProxy.js
@@ -95,6 +95,7 @@ HttpProxy.prototype.init = function (proxy) {
       try {
         stream = new HttpFormDataStream({headers: request.headers, limits: {fileSize: this.maxFileSize}}, payload, throwSizeLimitError);
       } catch (error) {
+        request.resume();
         return replyWithError(connection.id, payload, response, new BadRequestError(error.message));
       }
     }

--- a/lib/service/HttpProxy.js
+++ b/lib/service/HttpProxy.js
@@ -6,6 +6,7 @@ let
   uuid = require('uuid'),
   url = require('url'),
   ClientConnection = require('../core/clientConnection'),
+  BadRequestError = require('kuzzle-common-objects').errors.BadRequestError,
   SizeLimitError = require('kuzzle-common-objects').errors.SizeLimitError,
   Writable = require('stream').Writable,
   HttpFormDataStream = require('./HttpFormDataStream'),
@@ -91,7 +92,11 @@ HttpProxy.prototype.init = function (proxy) {
         }
       });
     } else {
-      stream = new HttpFormDataStream({headers: request.headers, limits: {fileSize: this.maxFileSize}}, payload, throwSizeLimitError);
+      try {
+        stream = new HttpFormDataStream({headers: request.headers, limits: {fileSize: this.maxFileSize}}, payload, throwSizeLimitError);
+      } catch (error) {
+        return replyWithError(connection.id, payload, response, new BadRequestError(error.message));
+      }
     }
 
     request.on('data', chunk => {

--- a/lib/service/HttpProxy.js
+++ b/lib/service/HttpProxy.js
@@ -108,7 +108,7 @@ HttpProxy.prototype.init = function (proxy) {
        * max size limit while reading the stream too
        */
       if (stream_length > this.maxRequestSize) {
-        throwSizeLimitError();
+        return throwSizeLimitError();
       }
       stream.write(chunk);
     });

--- a/lib/service/HttpProxy.js
+++ b/lib/service/HttpProxy.js
@@ -114,9 +114,10 @@ HttpProxy.prototype.init = function (proxy) {
     });
 
     request.on('end', () => {
-      payload.headers['content-type'] = 'application/json';
-      stream.emit('end');
-      sendRequest(connection.id, response, payload);
+      stream.end(() => {
+        payload.headers['content-type'] = 'application/json';
+        sendRequest(connection.id, response, payload);
+      });
     });
   });
 

--- a/lib/service/HttpProxy.js
+++ b/lib/service/HttpProxy.js
@@ -6,6 +6,7 @@ const
   uuid = require('uuid'),
   url = require('url'),
   SizeLimitError = require('kuzzle-common-objects').errors.SizeLimitError,
+  Writable = require('stream').Writable,
   KuzzleRoom = 'httpRequest';
 
 /**
@@ -37,6 +38,13 @@ HttpProxy.prototype.init = function (context, config) {
 
   this.server = http.createServer((request, response) => {
     let
+      stream = new Writable({
+        write(chunk, encoding, callback) {
+          payload.content += chunk.toString();
+          callback();
+        }
+      }),
+      stream_length = 0,
       payload = {
         requestId: uuid.v4(),
         url: request.url,
@@ -51,20 +59,21 @@ HttpProxy.prototype.init = function (context, config) {
     }
 
     request.on('data', chunk => {
-      payload.content += chunk.toString();
+      stream_length += chunk.length;
 
       /*
        * The content-length header can be bypassed and
        * is not reliable enough. We have to enforce the HTTP
        * max size limit while reading the stream too
        */
-      if (payload.content.length > this.maxRequestSize) {
+      if (stream_length > this.maxRequestSize) {
         request
           .removeAllListeners('data')
           .removeAllListeners('end')
           .resume();
         return replyWithError(response, new SizeLimitError('Error: maximum HTTP request size exceeded'));
       }
+      stream.write(chunk);
     });
 
     request.on('end', () => {

--- a/lib/service/HttpProxy.js
+++ b/lib/service/HttpProxy.js
@@ -71,16 +71,10 @@ HttpProxy.prototype.init = function (proxy) {
     const connection = new ClientConnection('HTTP/' + request.httpVersion, ips, request.headers);
     _proxy.clientConnectionStore.add(connection);
 
-    const throwSizeLimitError = () => {
-      request
-        .removeAllListeners('data')
-        .removeAllListeners('end')
-        .resume();
-      return replyWithError(connection.id, payload, response, new SizeLimitError('Error: maximum HTTP request size exceeded'));
-    };
-
     if (request.headers['content-length'] > this.maxRequestSize) {
-      request.resume();
+      request
+        .removeAllListeners()
+        .resume();
       return replyWithError(connection.id, payload, response, new SizeLimitError('Error: maximum HTTP request size exceeded'));
     }
 
@@ -91,13 +85,37 @@ HttpProxy.prototype.init = function (proxy) {
           callback();
         }
       });
+
+      stream.on('error', err => {
+        stream.end();
+        request
+          .removeAllListeners('data')
+          .removeAllListeners('end')
+          .resume();
+        return replyWithError(connection.id, payload, response, err);
+      });
     } else {
       try {
-        stream = new HttpFormDataStream({headers: request.headers, limits: {fileSize: this.maxFileSize}}, payload, throwSizeLimitError);
+        stream = new HttpFormDataStream({headers: request.headers, limits: {fileSize: this.maxFileSize}}, payload);
       } catch (error) {
         request.resume();
         return replyWithError(connection.id, payload, response, new BadRequestError(error.message));
       }
+
+      stream.on('error', err => {
+        /*
+        * Force Dicer parser to finish prematurely
+        * without throwing an 'Unexpected end of multipart data' error :
+        */
+        stream._parser.parser._finished = true;
+        stream.end();
+
+        request
+          .removeAllListeners('data')
+          .removeAllListeners('end')
+          .resume();
+        return replyWithError(connection.id, payload, response, err);
+      });
     }
 
     request.on('data', chunk => {
@@ -109,8 +127,7 @@ HttpProxy.prototype.init = function (proxy) {
        * max size limit while reading the stream too
        */
       if (stream_length > this.maxRequestSize) {
-        stream.end();
-        return throwSizeLimitError();
+        return stream.emit('error', new SizeLimitError('Error: maximum HTTP request size exceeded'));
       }
       stream.write(chunk);
     });

--- a/lib/service/HttpProxy.js
+++ b/lib/service/HttpProxy.js
@@ -39,6 +39,10 @@ HttpProxy.prototype.init = function (proxy) {
     throw new Error('Invalid HTTP "maxRequestSize" parameter');
   }
 
+  if (this.maxFileSize === null || isNaN(this.maxFileSize)) {
+    throw new Error('Invalid HTTP "maxFileSize" parameter');
+  }
+
   if (!proxy.config.http.port) {
     throw new Error('No HTTP port configured.');
   }

--- a/lib/service/HttpProxy.js
+++ b/lib/service/HttpProxy.js
@@ -51,7 +51,7 @@ HttpProxy.prototype.init = function (proxy) {
   this.server = http.createServer((request, response) => {
     let
       stream,
-      stream_length = 0,
+      streamLength = 0,
       payload = {
         requestId: uuid.v4(),
         url: request.url,
@@ -119,14 +119,14 @@ HttpProxy.prototype.init = function (proxy) {
     }
 
     request.on('data', chunk => {
-      stream_length += chunk.length;
+      streamLength += chunk.length;
 
       /*
        * The content-length header can be bypassed and
        * is not reliable enough. We have to enforce the HTTP
        * max size limit while reading the stream too
        */
-      if (stream_length > this.maxRequestSize) {
+      if (streamLength > this.maxRequestSize) {
         return stream.emit('error', new SizeLimitError('Error: maximum HTTP request size exceeded'));
       }
       stream.write(chunk);

--- a/lib/service/HttpProxy.js
+++ b/lib/service/HttpProxy.js
@@ -16,6 +16,7 @@ const
  */
 function HttpProxy () {
   this.maxRequestSize = null;
+  this.maxFileSize = null;
   this.server = null;
   return this;
 }
@@ -28,6 +29,7 @@ function HttpProxy () {
  */
 HttpProxy.prototype.init = function (context, config) {
   this.maxRequestSize = bytes.parse(config.http.maxRequestSize);
+  this.maxFileSize = bytes.parse(config.http.maxFileSize);
 
   if (this.maxRequestSize === null || isNaN(this.maxRequestSize)) {
     throw new Error('Invalid HTTP "maxRequestSize" parameter');
@@ -38,6 +40,15 @@ HttpProxy.prototype.init = function (context, config) {
   }
 
   this.server = http.createServer((request, response) => {
+
+    const throwSizeLimitError = () => {
+      request
+        .removeAllListeners('data')
+        .removeAllListeners('end')
+        .resume();
+      return replyWithError(response, new SizeLimitError('Error: maximum HTTP request size exceeded'));
+    };
+
     let
       stream,
       stream_length = 0,
@@ -62,7 +73,7 @@ HttpProxy.prototype.init = function (context, config) {
         }
       });
     } else {
-      stream = new HttpFormDataStream({headers: request.headers}, payload);
+      stream = new HttpFormDataStream({headers: request.headers, limits: {fileSize: this.maxFileSize}}, payload, throwSizeLimitError);
     }
 
     request.on('data', chunk => {
@@ -74,11 +85,7 @@ HttpProxy.prototype.init = function (context, config) {
        * max size limit while reading the stream too
        */
       if (stream_length > this.maxRequestSize) {
-        request
-          .removeAllListeners('data')
-          .removeAllListeners('end')
-          .resume();
-        return replyWithError(response, new SizeLimitError('Error: maximum HTTP request size exceeded'));
+        throwSizeLimitError();
       }
       stream.write(chunk);
     });

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "async": "^2.0.1",
     "bluebird": "^3.4.1",
     "bufferutil": "^1.2.1",
+    "busboy": "0.2.13",
     "bytes": "^2.4.0",
     "cli-color": "^1.1.0",
     "compare-versions": "^3.0.0",

--- a/test/service/httpProxy.test.js
+++ b/test/service/httpProxy.test.js
@@ -83,6 +83,13 @@ describe('/service/httpProxy', () => {
         .throw('Invalid HTTP "maxRequestSize" parameter');
     });
 
+    it('should throw if an invalid maxFileSize is given', () => {
+      proxy.config.http.maxFileSize = 'invalid';
+
+      return should(() => httpProxy.init(proxy))
+        .throw('Invalid HTTP "maxFileSize" parameter');
+    });
+
     it('should throw if no port is given', () => {
       delete proxy.config.http.port;
 

--- a/test/service/httpProxy.test.js
+++ b/test/service/httpProxy.test.js
@@ -113,16 +113,6 @@ describe('/service/httpProxy', () => {
 
         cb(request, response);
 
-        should(proxy.clientConnectionStore.add)
-          .be.calledOnce()
-          .be.calledWithMatch({
-            protocol: 'HTTP/1.1',
-            ips: ['2.2.2.2', '1.1.1.1'],
-            headers: {
-              'x-forwarded-for': '2.2.2.2',
-              'x-foo': 'bar'
-            }
-          });
         should(request.resume)
           .be.calledOnce();
         should(HttpProxy.__get__('replyWithError'))
@@ -161,6 +151,17 @@ describe('/service/httpProxy', () => {
       let cb = HttpProxy.__get__('http').createServer.firstCall.args[0];
 
       cb(request, response);
+
+      should(proxy.clientConnectionStore.add)
+        .be.calledOnce()
+        .be.calledWithMatch({
+          protocol: 'HTTP/1.1',
+          ips: ['2.2.2.2', '1.1.1.1'],
+          headers: {
+            'x-forwarded-for': '2.2.2.2',
+            'x-foo': 'bar'
+          }
+        });
 
       let dataCB = request.on.firstCall.args[1];
       dataCB('chunk1');

--- a/test/service/httpProxy.test.js
+++ b/test/service/httpProxy.test.js
@@ -242,7 +242,7 @@ describe('/service/httpProxy', () => {
           .be.calledTwice();
 
         should(HttpProxy.__get__('replyWithError'))
-          .be.calledWithMatch(/^[0-9a-z-]+$/, {url: request.url, method: request.method}, response, {message: 'Error: maximum HTTP request size exceeded'});
+          .be.calledWithMatch(/^[0-9a-z-]+$/, {url: request.url, method: request.method}, response, {message: 'Error: maximum HTTP file size exceeded'});
       });
     });
 

--- a/test/service/httpProxy.test.js
+++ b/test/service/httpProxy.test.js
@@ -23,7 +23,7 @@ describe('/service/httpProxy', () => {
       },
       config: {
         http: {
-          maxRequestSize: '100k',
+          maxRequestSize: '100kb',
           port: 1234,
           host: 'host'
         }


### PR DESCRIPTION
Add the capability to support both `application/x-www-form-urlencoded` and `multpart/form-data` content-types for HTTP requests.
This will enable clients to upload files through HTTP.

All incoming messages are turned into JSON data, to let Kuzzle core always manage JSON inputs.

Binary files are base64-encoded and encapsuled within following sample request format:
```json
{
  "requestId": "bbbebe25-7d6a-4079-b9a8-5f7b3c544094",
  "url": "/foo/bar/baz",
  "method": "PUT",
  "headers":  {
    "host": "kuzzle:7511",
    "content-type": "application/json",
    "content-length": "515"
  },
  "content": {
    "some-scalar-param": "scalar-value",
    "myfile":{
      "filename":"myfile.png",
      "encoding":"7bit",
      "mimetype":"image/png",
      "file":"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACklEQVQI12P4DwABAQEAG7buVgAAAABJRU5ErkJggg=="
    }
  }
}
```

---

Also refactored unit tests on HttpProxy, to run real unit tests on input requests