### PR TITLE
Fix #49: incorrect stringified Buffer detection in raw responses

### DIFF
--- a/lib/service/HttpProxy.js
+++ b/lib/service/HttpProxy.js
@@ -160,13 +160,6 @@ function sendRequest (connectionId, response, payload) {
     if (result) {
       _proxy.clientConnectionStore.remove(connectionId);
 
-      let indent = 0;
-      const parsedUrl = url.parse(payload.url, true);
-
-      if (parsedUrl.query && parsedUrl.query.pretty !== undefined) {
-        indent = 2;
-      }
-
       if (result.headers) {
         Object.keys(result.headers)
           .forEach(header => {
@@ -175,23 +168,7 @@ function sendRequest (connectionId, response, payload) {
       }
 
       response.writeHead(result.status);
-
-      if (result.raw) {
-        // binary data are sent as-is
-        if (result.content instanceof Buffer) {
-          return response.end(result.content);
-        }
-
-        // all JS objects are serialized, including arrays
-        if (typeof result.content === 'object') {
-          return response.end(JSON.stringify(result.content));
-        }
-
-        // scalars are sent as-is
-        return response.end(result.content);
-      }
-
-      response.end(JSON.stringify(result.content, undefined, indent));
+      response.end(contentToPayload(result, payload.url));
     }
     else {
       replyWithError(connectionId, payload, response, error);
@@ -223,6 +200,52 @@ function replyWithError(connectionId, payload, response, error) {
   });
 
   response.end(result.content);
+}
+
+/**
+ * Converts a Kuzzle query result into an appropriate payload format
+ * to send back to the client
+ *
+ * @param {Object} result
+ * @param {String} invokedUrl - invoked URL. Used to check if the ?pretty
+ *                              argument was passed by the client, changing
+ *                              the payload format
+ * @return {String|Buffer}
+ */
+function contentToPayload(result, invokedUrl) {
+  let data;
+
+  if (result.raw) {
+    if (typeof result.content === 'object') {
+      /*
+       Either the content can be stored in a Buffer object, or
+       the conversion throws and we stringify the content
+       instead
+       */
+      if (result.content instanceof Buffer || (result.content.type === 'Buffer' && Array.isArray(result.content.data))) {
+        data = Buffer.from(result.content);
+      }
+      else {
+        data = JSON.stringify(result.content);
+      }
+    }
+    else {
+      // scalars are sent as-is
+      data = result.content;
+    }
+  }
+  else {
+    let indent = 0;
+    const parsedUrl = url.parse(invokedUrl, true);
+
+    if (parsedUrl.query && parsedUrl.query.pretty !== undefined) {
+      indent = 2;
+    }
+
+    data = JSON.stringify(result.content, undefined, indent);
+  }
+
+  return data
 }
 
 module.exports = HttpProxy;

--- a/lib/service/HttpProxy.js
+++ b/lib/service/HttpProxy.js
@@ -246,7 +246,7 @@ function contentToPayload(result, invokedUrl) {
     data = JSON.stringify(result.content, undefined, indent);
   }
 
-  return data
+  return data;
 }
 
 module.exports = HttpProxy;

--- a/lib/service/HttpProxy.js
+++ b/lib/service/HttpProxy.js
@@ -218,9 +218,10 @@ function contentToPayload(result, invokedUrl) {
   if (result.raw) {
     if (typeof result.content === 'object') {
       /*
-       Either the content can be stored in a Buffer object, or
-       the conversion throws and we stringify the content
-       instead
+       This object can be either a Buffer object, a stringified Buffer object,
+       or anything else.
+       In the former two cases, we create a new Buffer object, and in the latter,
+       we stringify the content.
        */
       if (result.content instanceof Buffer || (result.content.type === 'Buffer' && Array.isArray(result.content.data))) {
         data = Buffer.from(result.content);

--- a/test/service/httpProxy.test.js
+++ b/test/service/httpProxy.test.js
@@ -362,6 +362,23 @@ describe('/service/httpProxy', () => {
         .be.calledWith(result.content);
     });
 
+    it('should output a stringified buffer as a raw buffer result', () => {
+      const result = {
+        raw: true,
+        status: 'status',
+        content: JSON.parse(JSON.stringify(new Buffer('test')))
+      };
+
+      sendRequest('connectionId', response, payload);
+      const cb = proxy.broker.brokerCallback.firstCall.args[4];
+
+      cb(undefined, result);
+
+      should(response.end)
+        .be.calledOnce()
+        .be.calledWithMatch(Buffer.from(result.content));
+    });
+
     it('should output serialized JS objects marked as raw', () => {
       const result = {
         raw: true,


### PR DESCRIPTION
* Adds a new check to detect stringified Buffer in raw HTTP responses, in order to convert them back to a Buffer object before sending the payload back to the client (fix #49)
* As the code to convert result content has grown over time, it has been isolated in a separate function, making `sendRequest` more readable