### PR TITLE
Develop add debug mode

### DIFF
--- a/docker-compose/dev.yml
+++ b/docker-compose/dev.yml
@@ -1,0 +1,33 @@
+version: '2'
+
+services:
+  proxy:
+    image: kuzzleio/dev
+    command: sh -c 'chmod 755 /run.sh && /run.sh'
+    volumes:
+      - "..:/var/app"
+      - "./scripts/run-dev.sh:/run.sh"
+      - "./config/pm2-dev.json:/config/pm2.json"
+    ports:
+      - "7511-7513:7511-7513"
+    environment:
+      - NODE_ENV=development
+
+  kuzzle:
+    image: kuzzleio/kuzzle:develop
+    depends_on:
+      - proxy
+      - redis
+      - elasticsearch
+    environment:
+      - kuzzle_services__db__host=elasticsearch
+      - kuzzle_services__internalCache__node__host=redis
+      - kuzzle_services__memoryStorage__node__host=redis
+      - kuzzle_services__proxyBroker__host=proxy
+      - NODE_ENV=development
+
+  redis:
+    image: redis:3.2
+
+  elasticsearch:
+    image: elasticsearch:5.0

--- a/docker-compose/scripts/run-dev.sh
+++ b/docker-compose/scripts/run-dev.sh
@@ -9,6 +9,4 @@ sleep 1
 echo "[$(date --rfc-3339 seconds)] - Starting Kuzzle Proxy..."
 
 pm2 start --silent /config/pm2.json
-pm2 sendSignal -s SIGUSR1 KuzzleProxy
-nohup node-inspector --web-port=8080 --debug-port=7003 > /dev/null 2>&1&
 pm2 logs --lines 0 --raw

--- a/lib/core/KuzzleProxy.js
+++ b/lib/core/KuzzleProxy.js
@@ -1,6 +1,7 @@
 'use strict';
 
 let
+  debug = require('debug')('kuzzle-proxy:plugins'),
   Broker = require('../service/Broker'),
   ClientConnectionStore = require('../store/ClientConnection'),
   Context = require('./Context'),
@@ -99,10 +100,15 @@ class KuzzleProxy {
    * Reads configuration files and initializes plugins
    */
   initPlugins () {
+    debug('initializing plugins');
+
     Object.keys(this.config.protocolPlugins).forEach(pluginName => {
       let
         plugin,
         pluginDefinition = this.config.protocolPlugins[pluginName];
+
+
+      debug('[%s] initializing plugin with definition:\n%O', pluginName, pluginDefinition);
 
       if (!pluginDefinition.activated) {
         return;
@@ -118,6 +124,8 @@ class KuzzleProxy {
         this.log.error(`Initialization of plugin ${pluginName} has failed; Reason: `, error.stack);
       }
     });
+
+    debug('plugins initialized');
   }
 
   initLogger () {

--- a/lib/plugins/package.js
+++ b/lib/plugins/package.js
@@ -1,4 +1,5 @@
 var
+  debug = require('debug')('kuzzle-proxy:plugins'),
   compareVersions = require('compare-versions'),
   exec = require('child_process').exec,
   path = require('path'),
@@ -28,12 +29,18 @@ PluginPackage.prototype.setDefinition = function pkgSetDefinition (definition) {
 PluginPackage.prototype.isInstalled = function pkgIsInstalled () {
   var isInstalled = false;
 
+  debug('[%s] checking if plugin is installed in "%s"', this.name, `${rootDir}/node_modules/${this.name}/package.json`);
+
   try {
     require(`${rootDir}/node_modules/${this.name}/package.json`);
     isInstalled = true;
+
+    debug('[%s] configuration loaded successfully', this.name);
   }
   catch (error) {
     // do nothing
+
+    debug('[%s] unable to load plugin configuration', this.name);
   }
 
   return isInstalled;
@@ -81,6 +88,8 @@ PluginPackage.prototype.install = function pkgInstall () {
       pkg += '@' + this.version;
     }
   }
+
+  debug('[%s] installing plugin with npm from package "%s"', this.name, pkg);
 
   return Promise.promisify(exec)(`npm install ${pkg}`);
 };

--- a/lib/service/Backend.js
+++ b/lib/service/Backend.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const
+  debug = require('debug')('kuzzle-proxy:backend'),
   PendingRequest = require('../store/PendingRequest'),
   util = require('util'),
   InternalError = require('kuzzle-common-objects').errors.InternalError;
@@ -42,6 +43,8 @@ function Backend (backendSocket, proxy, backendTimeout) {
 Backend.prototype.onMessage = function (payload) {
   let message;
 
+  debug('[%s] receiving message from backend:\n%O', this.socketIp, payload);
+
   try {
     message = JSON.parse(payload);
   }
@@ -63,13 +66,19 @@ Backend.prototype.onMessage = function (payload) {
 Backend.prototype.initializeMessageRooms = function () {
   return {
     response: (data) => {
+      debug('[%s] resolving backend response for request id "%s":\n%O' , this.socketIp, data.requestId, client);
+
       this.backendRequestStore.resolve(data.requestId, null, data);
     },
     httpResponse: (data) => {
+      debug('[%s] resolving backend HTTP response for request id "%s":\n%O' , this.socketIp, data.requestId, client);
+
       this.backendRequestStore.resolve(data.requestId, null, data);
     },
     joinChannel: (data) => {
       let client = _proxy.clientConnectionStore.get(data.connectionId);
+
+      debug('[%s] joining channel for client with connection id "%s":\n%O' , this.socketIp, data.connectionId, client);
 
       if (client && client.protocol) {
         try {
@@ -83,6 +92,8 @@ Backend.prototype.initializeMessageRooms = function () {
     leaveChannel: (data) => {
       let client = _proxy.clientConnectionStore.get(data.connectionId);
 
+      debug('[%s] leaving channel for client with connection id "%s":\n%O' , this.socketIp, data.connectionId, client);
+
       if (client && client.protocol) {
         try {
           _proxy.pluginStore.getByProtocol(client.protocol).leaveChannel(data);
@@ -95,6 +106,8 @@ Backend.prototype.initializeMessageRooms = function () {
     notify: (data) => {
       let client = _proxy.clientConnectionStore.get(data.connectionId);
 
+      debug('[%s] sending notification to client with connection id "%s":\n%O', this.socketIp, data.connectionId, client);
+
       if (client && client.protocol) {
         try {
           _proxy.pluginStore.getByProtocol(client.protocol).notify(data);
@@ -105,7 +118,11 @@ Backend.prototype.initializeMessageRooms = function () {
       }
     },
     broadcast: (data) => {
+      debug('[%s] broadcasting data through all protocols:\n%O', this.socketIp, data);
+
       Object.keys(_proxy.pluginStore.plugins).forEach(plugin => {
+        debug('[%s] broadcasting through protocol "%s"', this.socketIp, plugin);
+
         try {
           _proxy.pluginStore.plugins[plugin].broadcast(data);
         }
@@ -121,6 +138,8 @@ Backend.prototype.initializeMessageRooms = function () {
  * Triggered when the connection is closed
  */
 Backend.prototype.onConnectionClose = function () {
+  debug('[%s] connection with backend closed', this.socketIp);
+
   _proxy.log.warn(`Connection with backend ${this.socketIp} closed.`);
   _proxy.backendHandler.removeBackend(this);
   this.backendRequestStore.abortAll(new InternalError(`Connection with backend ${this.socketIp} closed.`));
@@ -135,6 +154,8 @@ Backend.prototype.onConnectionClose = function () {
  * @param {Error} error
  */
 Backend.prototype.onConnectionError = function(error) {
+  debug('[%s] connection with backend errored:\n%O', this.socketIp, error);
+
   _proxy.log.error(`Connection error with backend ${this.socketIp}; Reason: ${error}`);
   _proxy.backendHandler.removeBackend(this);
   this.backendRequestStore.abortAll(new InternalError(`Connection error with backend ${this.socketIp}; Reason: ${error}`));
@@ -149,6 +170,8 @@ Backend.prototype.onConnectionError = function(error) {
  * @param {Function} callback - Client's callback to resolve
  */
 Backend.prototype.send = function(room, id, data, callback) {
+  debug('[%s] sending message to backend in room "%s" with identifier "%s":\n%O', this.socketIp, room, id, data);
+
   this.backendRequestStore.add(id, data, callback);
   this.socket.send(JSON.stringify({room, data}));
 };
@@ -161,6 +184,8 @@ Backend.prototype.send = function(room, id, data, callback) {
  * @param {Function} callback
  */
 Backend.prototype.sendRaw = function(room, data, callback) {
+  debug('[%s] sending raw message to backend in room "%s":\n%O', this.socketIp, room, data);
+
   this.socket.send(JSON.stringify({room, data}), callback);
 };
 

--- a/lib/service/Backend.js
+++ b/lib/service/Backend.js
@@ -66,19 +66,19 @@ Backend.prototype.onMessage = function (payload) {
 Backend.prototype.initializeMessageRooms = function () {
   return {
     response: (data) => {
-      debug('[%s] resolving backend response for request id "%s":\n%O' , this.socketIp, data.requestId, client);
+      debug('[%s] resolving backend response for request id "%s":\n%O' , this.socketIp, data.requestId, data);
 
       this.backendRequestStore.resolve(data.requestId, null, data);
     },
     httpResponse: (data) => {
-      debug('[%s] resolving backend HTTP response for request id "%s":\n%O' , this.socketIp, data.requestId, client);
+      debug('[%s] resolving backend HTTP response for request id "%s":\n%O' , this.socketIp, data.requestId, data);
 
       this.backendRequestStore.resolve(data.requestId, null, data);
     },
     joinChannel: (data) => {
       let client = _proxy.clientConnectionStore.get(data.connectionId);
 
-      debug('[%s] joining channel for client with connection id "%s":\n%O' , this.socketIp, data.connectionId, client);
+      debug('[%s] joining channel for client with connection id "%s":\n%O' , this.socketIp, data.connectionId, data);
 
       if (client && client.protocol) {
         try {
@@ -92,7 +92,7 @@ Backend.prototype.initializeMessageRooms = function () {
     leaveChannel: (data) => {
       let client = _proxy.clientConnectionStore.get(data.connectionId);
 
-      debug('[%s] leaving channel for client with connection id "%s":\n%O' , this.socketIp, data.connectionId, client);
+      debug('[%s] leaving channel for client with connection id "%s":\n%O' , this.socketIp, data.connectionId, data);
 
       if (client && client.protocol) {
         try {
@@ -106,7 +106,7 @@ Backend.prototype.initializeMessageRooms = function () {
     notify: (data) => {
       let client = _proxy.clientConnectionStore.get(data.connectionId);
 
-      debug('[%s] sending notification to client with connection id "%s":\n%O', this.socketIp, data.connectionId, client);
+      debug('[%s] sending notification to client with connection id "%s":\n%O', this.socketIp, data.connectionId, data);
 
       if (client && client.protocol) {
         try {

--- a/lib/service/Broker.js
+++ b/lib/service/Broker.js
@@ -1,6 +1,7 @@
 'use strict';
 
 let
+  debug = require('debug')('kuzzle-proxy:broker'),
   fs = require('fs'),
   http = require('http'),
   net = require('net'),
@@ -34,6 +35,8 @@ function Broker () {
 Broker.prototype.init = function (proxy, config) {
   _proxy = proxy;
 
+  debug('initializing proxy broker with config:\n%O', config);
+
   this.config = config;
 
   this.initiateServer();
@@ -56,6 +59,8 @@ Broker.prototype.initiateServer = function () {
   if (this.config.socket) {
     server.on('error', error => {
       if (error.code !== 'EADDRINUSE') {
+        debug('broker server received an error:\n%O', error);
+
         throw error;
       }
 
@@ -65,8 +70,13 @@ Broker.prototype.initiateServer = function () {
       })
         .on('error', e => {
           if (e.code !== 'ECONNREFUSED') {
+            debug('broker server can\'t open requested socket, seem to be already used by another process');
+
             throw e;
           }
+
+          debug('broker server can\'t open requested socket, seem to be unused, trying to recreate it');
+
           fs.unlinkSync(this.config.socket);
           if (broker) {
             broker.close(() => {
@@ -77,13 +87,20 @@ Broker.prototype.initiateServer = function () {
           }
         });
     });
+
+    debug('initialize broker server through socket "%s"', this.config.socket);
+
     server.listen(this.config.socket, initCB);
   }
   else if (this.config.port) {
     if (this.config.host) {
+      debug('initialize broker server through net port "%s" on host "%s"', this.config.port, this.config.host);
+
       server.listen(this.config.port, this.config.host, initCB);
     }
     else {
+      debug('initialize broker server through net port "%s"', this.config.port);
+
       server.listen(this.config.port, initCB);
     }
   }
@@ -102,6 +119,8 @@ Broker.prototype.onConnection = function (backendSocket) {
   let
     backend = new Backend(backendSocket, _proxy, this.config.timeout),
     clientConnections = _proxy.clientConnectionStore.getAll();
+
+  debug('[%s] broker server received a connection', backendSocket.upgradeReq ? backendSocket.upgradeReq.headers['sec-websocket-key'] : 'unknown identifier');
 
   if (this.config.socket) {
     _proxy.log.info('Connection established with a new backend');
@@ -124,8 +143,12 @@ Broker.prototype.onConnection = function (backendSocket) {
  * @param {Error|undefined} error
  */
 Broker.prototype.handleBackendRegistration = function (error, backend) {
+  debug('broker server handle backend registration of backend:\n%O', backend);
+
   if (error) {
     // We presume the error comes from the socket connection and close it
+    debug('broker server handle backend registration error:\n%O', error);
+
     let backendIdentifier;
 
     if (this.config.socket) {
@@ -188,6 +211,8 @@ Broker.prototype.brokerCallback = function (room, id, connectionId, data, callba
  * @param {ClientConnection} connection
  */
 Broker.prototype.addClientConnection = function (connection) {
+  debug('broker server add client connection\n%O', connection);
+
   const context = new RequestContext({
     connectionId: connection.id,
     protocol: connection.protocol
@@ -199,9 +224,11 @@ Broker.prototype.addClientConnection = function (connection) {
 /**
  * Removes a client connection and spreads the word to all backends
  *
- * @param {ClientConnection} context
+ * @param {ClientConnection} connection
  */
 Broker.prototype.removeClientConnection = function (connection) {
+  debug('broker server remove client connection\n%O', connection);
+
   const context = new RequestContext({
     connectionId: connection.id,
     protocol: connection.protocol
@@ -217,6 +244,8 @@ Broker.prototype.removeClientConnection = function (connection) {
  * @param {object} data
  */
 Broker.prototype.broadcastMessage = function (room, data) {
+  debug('broker server broadcasting message on room "%s":\n%O', room, data);
+
   _proxy.backendHandler.getAllBackends().forEach(backend => backend.sendRaw(room, data));
 };
 

--- a/lib/service/Broker.js
+++ b/lib/service/Broker.js
@@ -120,7 +120,7 @@ Broker.prototype.onConnection = function (backendSocket) {
     backend = new Backend(backendSocket, _proxy, this.config.timeout),
     clientConnections = _proxy.clientConnectionStore.getAll();
 
-  debug('[%s] broker server received a connection', backendSocket.upgradeReq ? backendSocket.upgradeReq.headers['sec-websocket-key'] : 'unknown identifier');
+  debug('[%s] broker server received a connection', backendSocket.upgradeReq && backendSocket.upgradeReq.headers ? backendSocket.upgradeReq.headers['sec-websocket-key'] : 'unknown identifier');
 
   if (this.config.socket) {
     _proxy.log.info('Connection established with a new backend');

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "url": "https://github.com/kuzzleio/kuzzle-proxy.git"
   },
   "dependencies": {
+    "debug": "^2.6.0",
     "async": "^2.0.1",
     "bluebird": "^3.4.1",
     "bufferutil": "^1.2.1",


### PR DESCRIPTION
Add debug mode in kuzzle-proxy for `plugins`, `backend` and `broker` (should be extended)

## How to enable debug mode:
```shell
# enable node development mode
export NODE_ENV=development

# enable debug for all kuzzle messages
export DEBUG=kuzzle-proxy:*
# enable debug for kuzzle plugings messages
export DEBUG=kuzzle-proxy:plugins
# enable debug for both kuzzle plugings and broker messages
export DEBUG=kuzzle-proxy:plugins,kuzzle-proxy:broker

# restart kuzzle to take effect
pm2 restart all
```

*see more usages here: https://www.npmjs.com/package/debug#wildcards*

## Available debugs labels

* kuzzle-proxy:plugins
* kuzzle-proxy:broker
* kuzzle-proxy:backend

## Other

Added a docker-compose file for development mode with file change watcher
