### PR TITLE
Improve protocol settings + use requestMaxSize for all protocols

### DIFF
--- a/.proxyrc.sample
+++ b/.proxyrc.sample
@@ -13,24 +13,25 @@
     "mode": "standard",
     "timeout": 10000
   },
+  // ip on which the proxy should bind itself for http connections. Defaults to all interfaces
+  "host": "0.0.0.0",
+  // TCP port to listen to
+  "port": 7511,
+  // The size limit of a request. If it's a string, the
+  //       value is passed to the "bytes" library (https://www.npmjs.com/package/bytes).
+  //       If this is a number, then the value specifies the number of bytes.
+  "maxRequestSize": "1MB",
   // http proxy
   //
   // configuration of the http proxy server for Kuzzle
   // options
   //   enabled: true/false (if http is disabled, the server will be started only websocket and socketio protocols). Default to "true"
-  //   port:    TCP port to listen to
-  //   maxRequestSize: the size limit of a request. If it's a string, the
+  //   maxFormFileSize: the size limit of a file (for upload requests). If it's a string, the
   //       value is passed to the "bytes" library (https://www.npmjs.com/package/bytes).
   //       If this is a number, then the value specifies the number of bytes.
-  //   maxFileSize: the size limit of a file (for upload requests). If it's a string, the
-  //       value is passed to the "bytes" library (https://www.npmjs.com/package/bytes).
-  //       If this is a number, then the value specifies the number of bytes.
-  //   [host]:  ip on which the proxy should bind itself for http connections. Defaults to all interfaces
   "http": {
     "enabled": true,
-    "port": 7511,
-    "maxRequestSize": "1MB",
-    "maxFileSize": "1MB"
+    "maxFormFileSize": "1MB"
   },
   // websocket protocols
   //

--- a/.proxyrc.sample
+++ b/.proxyrc.sample
@@ -16,7 +16,7 @@
   // ip on which the proxy should bind itself for http connections. Defaults to all interfaces
   "host": "0.0.0.0",
   // TCP port to listen to
-  "port": 7511,
+  "port": 7512,
   // The size limit of a request. If it's a string, the
   //       value is passed to the "bytes" library (https://www.npmjs.com/package/bytes).
   //       If this is a number, then the value specifies the number of bytes.

--- a/lib/core/config.js
+++ b/lib/core/config.js
@@ -57,11 +57,11 @@ config = rc('proxy', {
     mode: 'standard',
     timeout: 10000
   },
+  port: 7512,
+  maxRequestSize: '1MB',
   http: {
     enabled: true,
-    port: 7512,
-    maxRequestSize: '1MB',
-    maxFileSize: '1MB'
+    maxFormFileSize: '1MB'
   },
   websocket: {
     enabled: true

--- a/lib/service/HttpProxy.js
+++ b/lib/service/HttpProxy.js
@@ -21,7 +21,7 @@ let _proxy = {};
  */
 function HttpProxy () {
   this.maxRequestSize = null;
-  this.maxFileSize = null;
+  this.maxFormFileSize = null;
   this.server = null;
   return this;
 }
@@ -32,10 +32,10 @@ function HttpProxy () {
  * @param {KuzzleProxy} proxy
  */
 HttpProxy.prototype.init = function (proxy) {
-  debug('initializing http Server with config:\n%O', proxy.config.http);
+  debug('initializing http Server with config:\n%O', proxy.config);
 
-  this.maxRequestSize = bytes.parse(proxy.config.http.maxRequestSize);
-  this.maxFileSize = bytes.parse(proxy.config.http.maxFileSize);
+  this.maxRequestSize = bytes.parse(proxy.config.maxRequestSize);
+  this.maxFormFileSize = bytes.parse(proxy.config.http.maxFormFileSize);
 
   _proxy = proxy;
 
@@ -43,18 +43,18 @@ HttpProxy.prototype.init = function (proxy) {
     throw new Error('Invalid HTTP "maxRequestSize" parameter');
   }
 
-  if (this.maxFileSize === null || isNaN(this.maxFileSize)) {
-    throw new Error('Invalid HTTP "maxFileSize" parameter');
+  if (this.maxFormFileSize === null || isNaN(this.maxFormFileSize)) {
+    throw new Error('Invalid HTTP "maxFormFileSize" parameter');
   }
 
-  if (!proxy.config.http.port) {
+  if (!proxy.config.port) {
     throw new Error('No HTTP port configured.');
   }
 
   if (! proxy.config.http.enabled) {
     debug('HTTP Disabled: server started only to manage websocket/socket.io protocols');
     this.server = http.createServer();
-    return this.server.listen(proxy.config.http.port, proxy.config.http.host);
+    return this.server.listen(proxy.config.port, proxy.config.host);
   }
 
   this.server = http.createServer((request, response) => {
@@ -108,7 +108,7 @@ HttpProxy.prototype.init = function (proxy) {
       });
     } else {
       try {
-        stream = new HttpFormDataStream({headers: request.headers, limits: {fileSize: this.maxFileSize}}, payload);
+        stream = new HttpFormDataStream({headers: request.headers, limits: {fileSize: this.maxFormFileSize}}, payload);
       } catch (error) {
         request.resume();
         return replyWithError(connection.id, payload, response, new BadRequestError(error.message));
@@ -156,7 +156,7 @@ HttpProxy.prototype.init = function (proxy) {
     });
   });
 
-  this.server.listen(proxy.config.http.port, proxy.config.http.host);
+  this.server.listen(proxy.config.port, proxy.config.host);
 };
 
 /**

--- a/lib/service/protocol/SocketIo.js
+++ b/lib/service/protocol/SocketIo.js
@@ -91,10 +91,18 @@ function SocketIo () {
   };
 
   this.onClientMessage = function (socket, clientId, data) {
-    debug('[%s] onClientMessage:\n%O', clientId, data);
-
     if (data && this.sockets[clientId]) {
       let request;
+
+      if (data.toString().length > _proxy.httpProxy.maxRequestSize) {
+        _proxy.log.error('[socketio] Input message length(' + data.length + ') exceed maxRequestSize: ' + _proxy.httpProxy.maxRequestSize);
+        return this.io.to(socket.id).emit(data.requestId, {
+          status: 413,
+          error: {message: 'Error: maximum input request size exceeded'}
+        });
+      }
+
+      debug('[%s] onClientMessage:\n%O', clientId, data);
 
       try {
         request = new Request(data, {

--- a/lib/service/protocol/Websocket.js
+++ b/lib/service/protocol/Websocket.js
@@ -6,7 +6,8 @@ const
   WebSocketServer = require('ws').Server,
   ClientConnection = require('../../core/clientConnection'),
   Request = require('kuzzle-common-objects').Request,
-  BadRequestError = require('kuzzle-common-objects').errors.BadRequestError;
+  BadRequestError = require('kuzzle-common-objects').errors.BadRequestError,
+  SizeLimitError = require('kuzzle-common-objects').errors.SizeLimitError;
 
 let
   _proxy = {};
@@ -107,10 +108,15 @@ function Websocket () {
   };
 
   this.onClientMessage = function (clientId, data) {
-    debug('[%s] onClientMessage:\n%O', clientId, data);
-
     if (data && this.connectionPool[clientId]) {
       let parsed;
+
+      if (data.length > _proxy.httpProxy.maxRequestSize) {
+        _proxy.log.error('[websocket] Input message length(' + data.length + ') exceed maxRequestSize: ' + _proxy.httpProxy.maxRequestSize);
+        return send(this.connectionPool, clientId, JSON.stringify(new SizeLimitError('Error: maximum input request size exceeded')));
+      }
+
+      debug('[%s] onClientMessage:\n%O', clientId, data);
 
       try {
         parsed = JSON.parse(data);

--- a/test/service/httpProxy.test.js
+++ b/test/service/httpProxy.test.js
@@ -22,12 +22,12 @@ describe('/service/httpProxy', () => {
         remove: sinon.spy()
       },
       config: {
+        host: 'host',
+        port: 1234,
+        maxRequestSize: '100kb',
         http: {
           enabled: true,
-          maxRequestSize: '100kb',
-          maxFileSize: '100kb',
-          port: 1234,
-          host: 'host'
+          maxFormFileSize: '100kb'
         }
       },
       logAccess: sinon.spy()
@@ -91,21 +91,21 @@ describe('/service/httpProxy', () => {
     });
 
     it('should throw if an invalid maxRequestSize is given', () => {
-      proxy.config.http.maxRequestSize = 'invalid';
+      proxy.config.maxRequestSize = 'invalid';
 
       return should(() => httpProxy.init(proxy))
         .throw('Invalid HTTP "maxRequestSize" parameter');
     });
 
-    it('should throw if an invalid maxFileSize is given', () => {
-      proxy.config.http.maxFileSize = 'invalid';
+    it('should throw if an invalid maxFormFileSize is given', () => {
+      proxy.config.http.maxFormFileSize = 'invalid';
 
       return should(() => httpProxy.init(proxy))
-        .throw('Invalid HTTP "maxFileSize" parameter');
+        .throw('Invalid HTTP "maxFormFileSize" parameter');
     });
 
     it('should throw if no port is given', () => {
-      delete proxy.config.http.port;
+      delete proxy.config.port;
 
       return should(() => httpProxy.init(proxy))
         .throw('No HTTP port configured.');
@@ -114,7 +114,7 @@ describe('/service/httpProxy', () => {
     it('should init the http server', () => {
       should(httpProxy.server.listen)
         .be.calledOnce()
-        .be.calledWith(proxy.config.http.port, proxy.config.http.host);
+        .be.calledWith(proxy.config.port, proxy.config.host);
     });
 
     it('should respond with error if the request is too big', () => {
@@ -226,13 +226,13 @@ describe('/service/httpProxy', () => {
       endCB();
     });
 
-    it('should reply with error if the binary file size sent exceeds the maxFileSize', () => {
+    it('should reply with error if the binary file size sent exceeds the maxFormFileSize', () => {
       HttpProxy.__with__({
         replyWithError: sandbox.spy()
       })(() => {
         let cb = HttpProxy.__get__('http').createServer.firstCall.args[0];
 
-        httpProxy.maxFileSize = 2;
+        httpProxy.maxFormFileSize = 2;
         request.headers['content-type'] = 'multipart/form-data; boundary=---------------------------165748628625109734809700179';
         cb(request, response);
 


### PR DESCRIPTION
Since the merge of ports for all 3 core protocols, it's better now to setup the `host` and `port` settings in the config's root instead of the HTTP related config.

Also move `maxRequestSize` to root config and use it within websocket and socketio protocols