### PR TITLE
Remove unused bluebird dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   "dependencies": {
     "debug": "^2.6.0",
     "async": "^2.0.1",
-    "bluebird": "^3.4.1",
     "bufferutil": "^1.2.1",
     "busboy": "0.2.13",
     "bytes": "^2.4.0",

--- a/test/core/kuzzleProxy.test.js
+++ b/test/core/kuzzleProxy.test.js
@@ -5,7 +5,6 @@ const
   rewire = require('rewire'),
   should = require('should'),
   sinon = require('sinon'),
-  Promise = require('bluebird'),
   KuzzleProxy = rewire('../../lib/core/KuzzleProxy'),
   proxyConfig = require('../../lib/core/config');
 
@@ -82,8 +81,6 @@ describe('lib/core/KuzzleProxy', () => {
   describe('#start', () => {
     it('should call proper methods in order', () => {
       proxy.initLogger = sinon.spy();
-      proxy.installPluginsIfNeeded = sinon.stub().returns(Promise.resolve());
-
       proxy.start();
       should(proxy.initLogger)
         .be.calledOnce();


### PR DESCRIPTION
Bluebird was only used by one obsolete line in unit tests. It has been removed.