### PR TITLE
fixes #62 - empty errors coming from proxy

### DIFF
--- a/lib/service/Router.js
+++ b/lib/service/Router.js
@@ -39,7 +39,7 @@ Router.prototype.execute = function (request, callback) {
   _proxy.broker.brokerCallback('request', request.id, request.context.connectionId, request.serialize(), (error, result) => {
     if (error) {
       request.setError(error);
-      return callback(request.response);
+      return callback(request.response.toJSON());
     }
 
     callback(result);

--- a/lib/service/Router.js
+++ b/lib/service/Router.js
@@ -39,7 +39,10 @@ Router.prototype.execute = function (request, callback) {
   _proxy.broker.brokerCallback('request', request.id, request.context.connectionId, request.serialize(), (error, result) => {
     if (error) {
       request.setError(error);
-      return callback(request.response.toJSON());
+      if (typeof request.response.toJSON === 'function') {
+        return callback(request.response.toJSON());
+      }
+      return callback(request.response);
     }
 
     callback(result);


### PR DESCRIPTION
# Description

This PR fixes the case where an error issued by the proxy would be eventually be received as an empty string by the client.

# Related issue

* #62 

## Root cause

Errors are always embedded inside a [`RequestResponse`](https://github.com/kuzzleio/kuzzle-common-objects/blob/master/lib/models/requestResponse.js) object. In case the error is triggered by Kuzzle, the `response` object has already been serialized during the transport of the message from Kuzzle to the proxy.
This serialization process was not done when the error was directly issued by the proxy, and because the [`RequestResponse`](https://github.com/kuzzleio/kuzzle-common-objects/blob/master/lib/models/requestResponse.js) native object does not actually have any `content` property, the end result would be an empty string.