### PR TITLE
Fix http client connection leak

### DIFF
--- a/lib/service/HttpProxy.js
+++ b/lib/service/HttpProxy.js
@@ -174,7 +174,8 @@ function sendRequest (connectionId, response, payload) {
   }
 
   _proxy.broker.brokerCallback(KuzzleRoom, payload.requestId, connectionId, payload, (error, result) => {
-    debug('[%s] brokerCallback:\n%O\n%O', connectionId, error, result);
+    debug('[%s] brokerCallback:\nerror: %O\nresult: %O', connectionId, error, result);
+
     if (result) {
       _proxy.clientConnectionStore.remove(connectionId);
 
@@ -220,6 +221,8 @@ function replyWithError(connectionId, payload, response, error) {
   });
 
   response.end(result.content);
+
+  _proxy.clientConnectionStore.remove(connectionId);
 }
 
 /**

--- a/test/service/httpProxy.test.js
+++ b/test/service/httpProxy.test.js
@@ -449,6 +449,17 @@ describe('/service/httpProxy', () => {
           'Access-Control-Allow-Headers': 'Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With'
         });
     });
+
+    it('should remove pending request from clientConnectionStore', () => {
+      const error = new Error('test');
+      error.status = 'status';
+
+      replyWithError('connectionId', 'payload', response, error);
+
+      should(proxy.clientConnectionStore.remove)
+        .be.calledOnce()
+        .be.calledWithMatch('connectionId');
+    });
   });
 
 });


### PR DESCRIPTION
# Description

When an HTTP request is errored it was never removed from `clientConnectionStore`

This result with a bad behavior: each request will be resend to backend when a new registration is done (HTTP connection is already ended)