### PR TITLE
Add support for Kuzzle graceful shutdown

### DIFF
--- a/lib/service/Backend.js
+++ b/lib/service/Backend.js
@@ -38,6 +38,7 @@ const
 class Backend {
   constructor(backendSocket, proxy, backendTimeout) {
     this.proxy = proxy;
+    this.active = true;
 
     /** @type {PendingRequest} */
     this.backendRequestStore = new PendingRequest(backendTimeout);
@@ -155,6 +156,13 @@ class Backend {
             this.proxy.log.error(`[Broadcast] Protocol ${protocol} failed: ${e.message}\nNotification data:\n%s`, util.inspect(cleanData, {depth: null}));
           }
         });
+      },
+      shutdown: () => {
+        if (this.active) {
+          this.active = false;
+          debug('[%s] kuzzle node shutting down', this.socketIp);
+          this.proxy.backendHandler.removeBackend(this);
+        }
       }
     };
   }
@@ -166,7 +174,11 @@ class Backend {
     debug('[%s] connection with backend closed', this.socketIp);
 
     this.proxy.log.warn(`Connection with backend ${this.socketIp} closed.`);
-    this.proxy.backendHandler.removeBackend(this);
+
+    if (this.active) {
+      this.proxy.backendHandler.removeBackend(this);
+    }
+    
     this.backendRequestStore.abortAll(new KuzzleInternalError(`Connection with backend ${this.socketIp} closed.`));
 
     // We ensure the socket is closed to avoid weird side effects
@@ -182,7 +194,11 @@ class Backend {
     debug('[%s] connection with backend errored:\n%O', this.socketIp, error);
 
     this.proxy.log.error(`Connection error with backend ${this.socketIp}; Reason: ${error}`);
-    this.proxy.backendHandler.removeBackend(this);
+
+    if (this.active) {
+      this.proxy.backendHandler.removeBackend(this);
+    }
+
     this.backendRequestStore.abortAll(new KuzzleInternalError(`Connection error with backend ${this.socketIp}; Reason: ${error}`));
   }
 

--- a/lib/service/Broker.js
+++ b/lib/service/Broker.js
@@ -167,20 +167,13 @@ class Broker {
       // We presume the error comes from the socket connection and close it
       debug('broker server handle backend registration error: %a', error);
 
-
       let backendIdentifier;
 
       if (this.config.socket) {
         backendIdentifier = this.config.socket;
       }
       else {
-        if (this.config.host) {
-          backendIdentifier = this.config.host + ':';
-        }
-        else {
-          backendIdentifier = '0.0.0.0:';
-        }
-        backendIdentifier += this.config.port;
+        backendIdentifier = `${this.config.host || '0.0.0.0'}:${this.config.port}`;
       }
 
       this.proxy.log.error('Failed to init connection with backend %s:\n%s', backendIdentifier, error.stack);

--- a/test/service/backend.test.js
+++ b/test/service/backend.test.js
@@ -335,6 +335,22 @@ describe('service/Backend', () => {
         .be.calledOnce()
         .be.calledWith(data);
     });
+
+    it('#shutdown', () => {
+      backend.onMessageRooms.shutdown();
+
+      should(proxy.backendHandler.removeBackend)
+        .be.calledOnce()
+        .be.calledWith(backend);
+    });
+
+    it('#shutdown should do nothing if invoked more than once', () => {
+      backend.active = false;
+
+      backend.onMessageRooms.shutdown();
+
+      should(proxy.backendHandler.removeBackend.called).be.false();
+    });
   });
 
 });


### PR DESCRIPTION
# Description

This PR adds support for the new `shutdown` signal, sent by Kuzzle nodes when they are about to shut themselves down.

This signal instructs the proxy to remove the node from the backend list, without invalidating requests registered on it. The remaining requests, if any, are invalidated and cleaned up only when the associated socket closes or ends up in an error state.

# Solved issue

https://github.com/kuzzleio/kuzzle/issues/816
