### PR TITLE
Filter volatile instead of metadata in access logs

### DIFF
--- a/lib/core/KuzzleProxy.js
+++ b/lib/core/KuzzleProxy.js
@@ -327,7 +327,7 @@ class KuzzleProxy {
           'timestamp',
           'requestId',
           'jwt',
-          'metadata',
+          'volatile',
           'body',
           'controller',
           'action',


### PR DESCRIPTION
fixes #65