### PR TITLE
Add request headers to request.context

### DIFF
--- a/lib/service/protocol/SocketIo.js
+++ b/lib/service/protocol/SocketIo.js
@@ -55,7 +55,7 @@ class SocketIo {
 
     this.proxy.protocolStore.add(_protocol, this);
   }
-  
+
   onServerError(error) {
     this.proxy.log.error('[socketio] An error has occured:\n' + error.stack);
   }
@@ -95,7 +95,7 @@ class SocketIo {
 
     socket.on('kuzzle', data => {
       debug('[%s] receiving a `kuzzle` event', connection.id);
-      this.onClientMessage(socket, connection.id, data);
+      this.onClientMessage(socket, connection, data);
     });
   }
 
@@ -108,8 +108,8 @@ class SocketIo {
     }
   }
 
-  onClientMessage(socket, clientId, data) {
-    if (data && this.sockets[clientId]) {
+  onClientMessage(socket, connection, data) {
+    if (data && this.sockets[connection.id]) {
       let request;
 
       if (data.toString().length > this.proxy.httpProxy.maxRequestSize) {
@@ -120,13 +120,14 @@ class SocketIo {
         });
       }
 
-      debug('[%s] onClientMessage: %a', clientId, data);
+      debug('[%s] onClientMessage: %a', connection.id, data);
 
       try {
         request = new Request(data, {
-          connectionId: clientId,
+          connectionId: connection.id,
           protocol: _protocol
         });
+        request.input.headers = connection.headers;
       }
       catch (e) {
         return this.io.to(socket.id).emit(data.requestId, {
@@ -179,7 +180,7 @@ class SocketIo {
 
   disconnect(connectionId) {
     debug('[%s] disconnect', connectionId);
-    
+
     if (this.sockets[connectionId]) {
       this.sockets[connectionId].disconnect();
     }

--- a/lib/service/protocol/Websocket.js
+++ b/lib/service/protocol/Websocket.js
@@ -104,7 +104,7 @@ class Websocket {
 
     clientSocket.on('message', data => {
       debug('[%s] receiving a `message` event', connection.id);
-      this.onClientMessage(connection.id, data);
+      this.onClientMessage(connection, data);
     });
   }
 
@@ -129,16 +129,16 @@ class Websocket {
     }
   }
 
-  onClientMessage(clientId, data) {
-    if (data && this.connectionPool[clientId]) {
+  onClientMessage(connection, data) {
+    if (data && this.connectionPool[connection.id]) {
       let parsed;
 
       if (data.length > this.proxy.httpProxy.maxRequestSize) {
         this.proxy.log.error(`[websocket] Input message length(${data.length}) exceed maxRequestSize: ${this.proxy.httpProxy.maxRequestSize}`);
-        return send(this.connectionPool, clientId, JSON.stringify(new SizeLimitError('Error: maximum input request size exceeded')));
+        return send(this.connectionPool, connection.id, JSON.stringify(new SizeLimitError('Error: maximum input request size exceeded')));
       }
 
-      debug('[%s] onClientMessage: %a', clientId, data);
+      debug('[%s] onClientMessage: %a', connection.id, data);
 
       try {
         parsed = JSON.parse(data);
@@ -151,16 +151,17 @@ class Websocket {
          So... the error is forwarded to the client, hoping he know
          what to do with it.
          */
-        return send(this.connectionPool, clientId, JSON.stringify(new BadRequestError(e.message)));
+        return send(this.connectionPool, connection.id, JSON.stringify(new BadRequestError(e.message)));
       }
 
       let request;
 
       try {
         request = new Request(parsed, {
-          connectionId: clientId,
+          connectionId: connection.id,
           protocol: _protocol
         });
+        request.input.headers = connection.headers;
       }
       catch (e) {
         const errobj = {
@@ -171,14 +172,14 @@ class Websocket {
           }
         };
 
-        return send(this.connectionPool, clientId, JSON.stringify(errobj));
+        return send(this.connectionPool, connection.id, JSON.stringify(errobj));
       }
 
       this.proxy.router.execute(request, response => {
         if (response.content && typeof response.content === 'object') {
           response.content.room = response.requestId;
         }
-        send(this.connectionPool, clientId, JSON.stringify(response.content));
+        send(this.connectionPool, connection.id, JSON.stringify(response.content));
       });
     }
   }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "cli-color": "^1.1.0",
     "compare-versions": "^3.0.0",
     "debug": "^2.6.0",
-    "kuzzle-common-objects": "2.1.0",
+    "kuzzle-common-objects": "3.0.4",
     "lodash": "^4.14.1",
     "moment": "^2.17.1",
     "proper-lockfile": "^2.0.0",


### PR DESCRIPTION
Add request headers (coming from HTTP handshake headers) to the request.context for both Websocket and SocketIO protocols (headers are already transmitted to Kuzzle for HTTP protocol)

This will enable kuzzle to handle restrictions according to some headers values.

fix #76 
