### PR TITLE
Fix 836 ghost rooms

### DIFF
--- a/lib/core/KuzzleProxy.js
+++ b/lib/core/KuzzleProxy.js
@@ -253,7 +253,7 @@ class KuzzleProxy {
 
     if (!connection) {
       return this.log.warn(`[access log] No connection retrieved for connection id: ${connectionId}\n` +
-        'Most likely, the connection was closed before the response we received.');
+        'Most likely, the connection was closed before the response was received.');
     }
 
     if (this.config.logs.accessLogFormat === 'logstash') {

--- a/lib/service/Backend.js
+++ b/lib/service/Backend.js
@@ -22,6 +22,7 @@
 'use strict';
 
 const
+  async = require('async'),
   debug = require('../kuzzleDebug')('kuzzle-proxy:backend'),
   PendingRequest = require('../store/PendingRequest'),
   util = require('util'),
@@ -38,7 +39,7 @@ const
 class Backend {
   constructor(backendSocket, proxy, backendTimeout) {
     this.proxy = proxy;
-    this.active = true;
+    this.active = false;
 
     /** @type {PendingRequest} */
     this.backendRequestStore = new PendingRequest(backendTimeout);
@@ -85,6 +86,27 @@ class Backend {
 
   initializeMessageRooms() {
     return {
+      ready: () => {
+        debug('[%s] backend "%s" is ready', this.socketIp);
+
+        const clientConnections = this.proxy.clientConnectionStore.getAll();
+
+        async.each(
+          clientConnections,
+          (clientConnection, callback) => this.sendRaw('connection', {
+            connectionId: clientConnection.id,
+            protocol: clientConnection.protocol
+          }, callback),
+          error => {
+            if (error) {
+              this.proxy.log.error(`error on sending client connections to backend ${this.socketIp}`);
+            }
+
+            this.active = true;
+            this.proxy.backendHandler.activateBackend();
+          }
+        );
+      },
       response: data => {
         debug('[%s] resolving backend response for request id "%s": %a', this.socketIp, data.requestId, data);
 

--- a/lib/service/Backend.js
+++ b/lib/service/Backend.js
@@ -100,6 +100,7 @@ class Backend {
           error => {
             if (error) {
               this.proxy.log.error(`error on sending client connections to backend ${this.socketIp}`);
+              this.onConnectionClose();
             }
 
             this.active = true;

--- a/lib/service/Backend.js
+++ b/lib/service/Backend.js
@@ -100,7 +100,7 @@ class Backend {
           error => {
             if (error) {
               this.proxy.log.error(`error on sending client connections to backend ${this.socketIp}`);
-              this.onConnectionClose();
+              return this.onConnectionClose();
             }
 
             this.active = true;

--- a/lib/service/Broker.js
+++ b/lib/service/Broker.js
@@ -28,7 +28,6 @@ const
   net = require('net'),
   WebSocketServer = require('ws').Server,
   Backend = require('./Backend'),
-  async = require('async'),
   RequestContext = require('kuzzle-common-objects').models.RequestContext,
   ServiceUnavailableError = require('kuzzle-common-objects').errors.ServiceUnavailableError;
 
@@ -135,8 +134,7 @@ class Broker {
    */
   onConnection(backendSocket) {
     const
-      backend = new Backend(backendSocket, this.proxy, this.config.timeout),
-      clientConnections = this.proxy.clientConnectionStore.getAll();
+      backend = new Backend(backendSocket, this.proxy, this.config.timeout);
 
     debug('[%s] broker server received a connection', backendSocket.upgradeReq && backendSocket.upgradeReq.headers ? backendSocket.upgradeReq.headers['sec-websocket-key'] : 'unknown identifier');
 
@@ -147,11 +145,7 @@ class Broker {
       this.proxy.log.info(`A connection has been established with backend ${backendSocket.upgradeReq.connection.remoteAddress}.`);
     }
 
-    async.each(
-      clientConnections,
-      (clientConnection, callback) => backend.sendRaw('connection', clientConnection, callback),
-      error => this.handleBackendRegistration(error, backend)
-    );
+    this.handleBackendRegistration(null, backend);
   }
 
   /**

--- a/lib/service/ProxyBackendHandler.js
+++ b/lib/service/ProxyBackendHandler.js
@@ -36,6 +36,7 @@ class ProxyBackendHandler {
 
     /** @type {Backend} */
     this.currentBackend = null;
+    this.pendingBackend = null;
   }
 
   /**
@@ -44,11 +45,15 @@ class ProxyBackendHandler {
    * @param {Backend} newBackend
    */
   addBackend(newBackend) {
+    this.pendingBackend = newBackend;
+  }
+
+  activateBackend(backend = this.pendingBackend) {
     if (this.currentBackend) {
       this.currentBackend.onConnectionClose();
     }
 
-    this.currentBackend = newBackend;
+    this.currentBackend = backend;
   }
 
   /**

--- a/test/core/kuzzleProxy.test.js
+++ b/test/core/kuzzleProxy.test.js
@@ -390,7 +390,7 @@ describe('lib/core/KuzzleProxy', () => {
       should(proxy.log.warn)
         .be.calledOnce()
         .be.calledWith('[access log] No connection retrieved for connection id: -1\n' +
-          'Most likely, the connection was closed before the response we received.');
+          'Most likely, the connection was closed before the response was received.');
 
       should(proxy.loggers.access.info)
         .have.callCount(0);

--- a/test/service/broker.test.js
+++ b/test/service/broker.test.js
@@ -175,7 +175,7 @@ describe('service/broker', () => {
   });
 
   describe('#onConnection', () => {
-    it('should register the backend and send it the active connections', (done) => {
+    it('should register the backend', (done) => {
       proxy.clientConnectionStore.getAll.returns([
         'foo',
         'bar'
@@ -184,11 +184,8 @@ describe('service/broker', () => {
 
       broker.onConnection('socket');
 
-      const backend = Broker.__get__('Backend').firstCall.returnValue;
-
-      should(backend.sendRaw)
-        .be.calledWith('connection', 'foo')
-        .be.calledWith('connection', 'bar');
+      should(Broker.__get__('Backend'))
+        .be.calledOnce();
     });
 
     it('should log a different message depending on the connection type', () => {

--- a/test/service/proxyBackendHandler.test.js
+++ b/test/service/proxyBackendHandler.test.js
@@ -4,7 +4,7 @@ var
   ProxyBackendHandler = require.main.require('lib/service/ProxyBackendHandler');
 
 describe('Test: service/ProxyBackendHandler', function () {
-  var
+  let
     sandbox;
 
   before(() => {
@@ -37,30 +37,43 @@ describe('Test: service/ProxyBackendHandler', function () {
     should(backendHandler.currentBackend).be.eql(null);
   });
 
-  it('method addBackend close the previous backend connection before attaching a new one if it exists', () => {
-    var
+  it('method addBackend sets the incoming backend as pending to keep the object alive', () => {
+    const
+      backend = {foo: 'bar'},
+      backendHandler = new ProxyBackendHandler('standard');
+
+    backendHandler.addBackend(backend);
+
+    should(backendHandler.pendingBackend)
+      .be.exactly(backend);
+  });
+
+  it('method activateBackend close the previous backend connection before attaching a new one if it exists', () => {
+    const
       backendMode = 'standard',
       backendHandler = new ProxyBackendHandler(backendMode),
       dummyBackend = {dummy: 'backend'},
       onCloseSpy = sandbox.spy();
 
     backendHandler.currentBackend = {onConnectionClose: onCloseSpy};
+    backendHandler.pendingBackend = dummyBackend;
 
-    backendHandler.addBackend(dummyBackend);
+    backendHandler.activateBackend();
 
     should(onCloseSpy.calledOnce).be.true();
     should(backendHandler.currentBackend).be.eql(dummyBackend);
   });
 
-  it('method addBackend does not close the previous backend connection before attaching a new one if it does not exist', () => {
-    var
+  it('method activateBackend does not close the previous backend connection before attaching a new one if it does not exist', () => {
+    const
       backendMode = 'standard',
       backendHandler = new ProxyBackendHandler(backendMode),
       dummyBackend = {dummy: 'backend'};
 
+    backendHandler.pendingBackend = dummyBackend;
     backendHandler.currentBackend = null;
 
-    backendHandler.addBackend(dummyBackend);
+    backendHandler.activateBackend();
 
     should(backendHandler.currentBackend).be.eql(dummyBackend);
   });


### PR DESCRIPTION
:warning: **MERGE ONLY WITH ITS [KUZZLE COUNTERPART](https://github.com/kuzzleio/kuzzle/pull/842)**

:information_source: This PR is a copy of https://github.com/kuzzleio/kuzzle-proxy/pull/73, which was accidently merged (already approved)

# Description

This PR partly fixes some unhandled exceptions on client disconnections (cf https://github.com/kuzzleio/kuzzle/issues/836)

Notably, this PR now waits for Kuzzle to be ready before sending it the clients list (prevents some cases where some `subscribe`/`join` actions could be received _after_ a disconnection occurs.