### PR TITLE
Change the router.execute plugin accessor to allow protocols to inject headers

### DIFF
--- a/lib/core/Context.js
+++ b/lib/core/Context.js
@@ -23,7 +23,7 @@
 
 const
   ClientConnection = require('./clientConnection'),
-  {errors} = require('kuzzle-common-objects');
+  errors = require('kuzzle-common-objects').errors;
 
 /**
  * Context constructor

--- a/lib/core/Context.js
+++ b/lib/core/Context.js
@@ -23,7 +23,7 @@
 
 const
   ClientConnection = require('./clientConnection'),
-  {Request, errors} = require('kuzzle-common-objects');
+  {errors} = require('kuzzle-common-objects');
 
 /**
  * Context constructor
@@ -38,12 +38,10 @@ class Context {
     /**
      Constructors exposed to plugins
      @namespace {Object} constructors
-     @property {Request} Request - Constructor for Kuzzle Request objects
      @property {ClientConnection} ClientConnection - Constructor for the Proxy client connection identifier
      */
     this.constructors = {
-      ClientConnection,
-      Request
+      ClientConnection
     };
 
     /**

--- a/lib/service/Router.js
+++ b/lib/service/Router.js
@@ -22,6 +22,7 @@
 'use strict';
 
 const
+  Request = require('kuzzle-common-objects').Request,
   ServiceUnavailableError = require('kuzzle-common-objects').errors.ServiceUnavailableError;
 
 /**
@@ -52,10 +53,16 @@ class Router {
   /**
    * Triggered when a protocol receives a message
    *
-   * @param {Request} request
+   * @param {Object} data with following format: {payload, connectionId, protocol, headers}
    * @param {Function} callback
    */
-  execute(request, callback) {
+  execute(data, callback) {
+    const request = new Request(data.payload, {
+      connectionId: data.connectionId,
+      protocol: data.protocol
+    });
+    request.input.headers = data.headers;
+
     this.proxy.broker.brokerCallback('request', request.id, request.context.connectionId, request.serialize(), (error, result) => {
       if (error) {
         request.setError(error);

--- a/lib/service/protocol/SocketIo.js
+++ b/lib/service/protocol/SocketIo.js
@@ -55,7 +55,7 @@ class SocketIo {
 
     this.proxy.protocolStore.add(_protocol, this);
   }
-  
+
   onServerError(error) {
     this.proxy.log.error('[socketio] An error has occured:\n' + error.stack);
   }
@@ -95,7 +95,7 @@ class SocketIo {
 
     socket.on('kuzzle', data => {
       debug('[%s] receiving a `kuzzle` event', connection.id);
-      this.onClientMessage(socket, connection.id, data);
+      this.onClientMessage(socket, connection, data);
     });
   }
 
@@ -108,8 +108,8 @@ class SocketIo {
     }
   }
 
-  onClientMessage(socket, clientId, data) {
-    if (data && this.sockets[clientId]) {
+  onClientMessage(socket, connection, data) {
+    if (data && this.sockets[connection.id]) {
       let request;
 
       if (data.toString().length > this.proxy.httpProxy.maxRequestSize) {
@@ -120,13 +120,14 @@ class SocketIo {
         });
       }
 
-      debug('[%s] onClientMessage: %a', clientId, data);
+      debug('[%s] onClientMessage: %a', connection.id, data);
 
       try {
         request = new Request(data, {
-          connectionId: clientId,
+          connectionId: connection.id,
           protocol: _protocol
         });
+        request.input.headers = connection.headers;
       }
       catch (e) {
         return this.io.to(socket.id).emit(data.requestId, {
@@ -179,7 +180,7 @@ class SocketIo {
 
   disconnect(connectionId) {
     debug('[%s] disconnect', connectionId);
-    
+
     if (this.sockets[connectionId]) {
       this.sockets[connectionId].disconnect();
     }

--- a/lib/service/protocol/SocketIo.js
+++ b/lib/service/protocol/SocketIo.js
@@ -24,8 +24,7 @@
 const
   _protocol = 'socketio',
   debug = require('../../kuzzleDebug')('kuzzle-proxy:socketio-protocol'),
-  ClientConnection = require('../../core/clientConnection'),
-  Request = require('kuzzle-common-objects').Request;
+  ClientConnection = require('../../core/clientConnection');
 
 /**
  * @CLASS SocketIo
@@ -110,8 +109,6 @@ class SocketIo {
 
   onClientMessage(socket, connection, data) {
     if (data && this.sockets[connection.id]) {
-      let request;
-
       if (data.toString().length > this.proxy.httpProxy.maxRequestSize) {
         this.proxy.log.error(`[socketio] Input message length(${data.length}) exceed maxRequestSize: ${this.proxy.httpProxy.maxRequestSize}`);
         return this.io.to(socket.id).emit(data.requestId, {
@@ -123,11 +120,14 @@ class SocketIo {
       debug('[%s] onClientMessage: %a', connection.id, data);
 
       try {
-        request = new Request(data, {
+        this.proxy.router.execute({
+          payload: data,
           connectionId: connection.id,
+          headers: connection.headers,
           protocol: _protocol
+        }, response => {
+          this.io.to(socket.id).emit(response.requestId, response.content);
         });
-        request.input.headers = connection.headers;
       }
       catch (e) {
         return this.io.to(socket.id).emit(data.requestId, {
@@ -137,10 +137,6 @@ class SocketIo {
           }
         });
       }
-
-      this.proxy.router.execute(request, response => {
-        this.io.to(socket.id).emit(request.id, response.content);
-      });
     }
   }
 

--- a/lib/service/protocol/Websocket.js
+++ b/lib/service/protocol/Websocket.js
@@ -104,7 +104,7 @@ class Websocket {
 
     clientSocket.on('message', data => {
       debug('[%s] receiving a `message` event', connection.id);
-      this.onClientMessage(connection.id, data);
+      this.onClientMessage(connection, data);
     });
   }
 
@@ -129,16 +129,16 @@ class Websocket {
     }
   }
 
-  onClientMessage(clientId, data) {
-    if (data && this.connectionPool[clientId]) {
+  onClientMessage(connection, data) {
+    if (data && this.connectionPool[connection.id]) {
       let parsed;
 
       if (data.length > this.proxy.httpProxy.maxRequestSize) {
         this.proxy.log.error(`[websocket] Input message length(${data.length}) exceed maxRequestSize: ${this.proxy.httpProxy.maxRequestSize}`);
-        return send(this.connectionPool, clientId, JSON.stringify(new SizeLimitError('Error: maximum input request size exceeded')));
+        return send(this.connectionPool, connection.id, JSON.stringify(new SizeLimitError('Error: maximum input request size exceeded')));
       }
 
-      debug('[%s] onClientMessage: %a', clientId, data);
+      debug('[%s] onClientMessage: %a', connection.id, data);
 
       try {
         parsed = JSON.parse(data);
@@ -151,16 +151,17 @@ class Websocket {
          So... the error is forwarded to the client, hoping he know
          what to do with it.
          */
-        return send(this.connectionPool, clientId, JSON.stringify(new BadRequestError(e.message)));
+        return send(this.connectionPool, connection.id, JSON.stringify(new BadRequestError(e.message)));
       }
 
       let request;
 
       try {
         request = new Request(parsed, {
-          connectionId: clientId,
+          connectionId: connection.id,
           protocol: _protocol
         });
+        request.input.headers = connection.headers;
       }
       catch (e) {
         const errobj = {
@@ -171,14 +172,14 @@ class Websocket {
           }
         };
 
-        return send(this.connectionPool, clientId, JSON.stringify(errobj));
+        return send(this.connectionPool, connection.id, JSON.stringify(errobj));
       }
 
       this.proxy.router.execute(request, response => {
         if (response.content && typeof response.content === 'object') {
           response.content.room = response.requestId;
         }
-        send(this.connectionPool, clientId, JSON.stringify(response.content));
+        send(this.connectionPool, connection.id, JSON.stringify(response.content));
       });
     }
   }

--- a/lib/service/protocol/Websocket.js
+++ b/lib/service/protocol/Websocket.js
@@ -26,7 +26,6 @@ const
   debug = require('../../kuzzleDebug')('kuzzle-proxy:websocket-protocol'),
   WebSocketServer = require('ws').Server,
   ClientConnection = require('../../core/clientConnection'),
-  Request = require('kuzzle-common-objects').Request,
   {
     BadRequestError,
     SizeLimitError
@@ -154,14 +153,18 @@ class Websocket {
         return send(this.connectionPool, connection.id, JSON.stringify(new BadRequestError(e.message)));
       }
 
-      let request;
-
       try {
-        request = new Request(parsed, {
+        this.proxy.router.execute({
+          payload: parsed,
           connectionId: connection.id,
+          headers: connection.headers,
           protocol: _protocol
+        }, response => {
+          if (response.content && typeof response.content === 'object') {
+            response.content.room = response.requestId;
+          }
+          send(this.connectionPool, connection.id, JSON.stringify(response.content));
         });
-        request.input.headers = connection.headers;
       }
       catch (e) {
         const errobj = {
@@ -174,13 +177,6 @@ class Websocket {
 
         return send(this.connectionPool, connection.id, JSON.stringify(errobj));
       }
-
-      this.proxy.router.execute(request, response => {
-        if (response.content && typeof response.content === 'object') {
-          response.content.room = response.requestId;
-        }
-        send(this.connectionPool, connection.id, JSON.stringify(response.content));
-      });
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "cli-color": "^1.1.0",
     "compare-versions": "^3.0.0",
     "debug": "^2.6.0",
-    "kuzzle-common-objects": "2.1.0",
+    "kuzzle-common-objects": "3.0.4",
     "lodash": "^4.14.1",
     "moment": "^2.17.1",
     "proper-lockfile": "^2.0.0",

--- a/test/core/context.test.js
+++ b/test/core/context.test.js
@@ -4,8 +4,7 @@ const
   errors = require('kuzzle-common-objects').errors,
   should = require('should'),
   ClientConnection = require('../../lib/core/clientConnection'),
-  Context = require('../../lib/core/Context'),
-  Request = require('kuzzle-common-objects').Request;
+  Context = require('../../lib/core/Context');
 
 describe('Test: core/Context', function () {
 
@@ -14,8 +13,6 @@ describe('Test: core/Context', function () {
 
     should(context.constructors.ClientConnection)
       .be.exactly(ClientConnection);
-    should(context.constructors.Request)
-      .be.exactly(Request);
     should(context.errors)
       .be.exactly(errors);
   });

--- a/test/service/protocol/socketIo.test.js
+++ b/test/service/protocol/socketIo.test.js
@@ -5,15 +5,13 @@ const
   should = require('should'),
   sinon = require('sinon'),
   EventEmitter = require('events'),
-  fakeRequest = {id: 'requestId', aRequest: 'Object', input: {headers: {foo: 'bar'}}},
-  requestStub = sinon.stub().returns({id: 'requestId', aRequest: 'Object', input: {}}),
+  fakeRequest = {payload: {aRequest: 'Object'}, connectionId: 'connectionId', protocol: 'socketio', headers: {foo: 'bar'}},
   emitStub = sinon.stub(),
   clientConnectionStub = function(protocol, ips, headers) {
     return {protocol: protocol, id: 'connectionId', headers: headers};
   },
   SocketIo = proxyquire('../../../lib/service/protocol/SocketIo', {
     '../../core/clientConnection': clientConnectionStub,
-    'kuzzle-common-objects': {Request: requestStub},
     'socket.io': () => {
       const emitter = new EventEmitter();
 
@@ -100,7 +98,6 @@ describe('/service/protocol/SocketIo', function () {
   });
 
   afterEach(() => {
-    requestStub.reset();
     onClientSpy.reset();
     clientSocketMock.disconnect.reset();
   });
@@ -272,13 +269,11 @@ describe('/service/protocol/SocketIo', function () {
     it('should do nothing if the data is undefined', function () {
       io.onClientMessage(clientSocketMock, connection, undefined);
       should(proxy.router.execute.callCount).be.eql(0);
-      should(requestStub.callCount).be.eql(0);
     });
 
     it('should do nothing if the client is unknown', function () {
       io.onClientMessage(clientSocketMock, badConnection, 'aPayload');
       should(proxy.router.execute.callCount).be.eql(0);
-      should(requestStub.callCount).be.eql(0);
     });
 
     it('should reply with error if the actual data sent exceeds the maxRequestSize', () => {
@@ -295,14 +290,7 @@ describe('/service/protocol/SocketIo', function () {
     });
 
     it('should execute the request if client and packet are ok', function () {
-      io.onClientMessage(clientSocketMock, connection, 'aPayload');
-
-      should(requestStub)
-        .be.calledOnce()
-        .be.calledWith('aPayload', {
-          connectionId: 'connectionId',
-          protocol: 'socketio'
-        });
+      io.onClientMessage(clientSocketMock, connection, {aRequest: 'Object'});
 
       should(proxy.router.execute)
         .be.calledOnce()
@@ -313,14 +301,13 @@ describe('/service/protocol/SocketIo', function () {
         .be.calledWith(clientSocketMock.id);
       should(io.io.to.firstCall.returnValue.emit)
         .be.calledOnce()
-        .be.calledWith('requestId', {requestId: 'foo'});
+        .be.calledWith('foo', {requestId: 'foo'});
     });
 
     it('should forward an error message to the client if a request cannot be instantiated', () => {
-      requestStub.throws({message: 'error'});
+      proxy.router.execute = sinon.stub().throws({message: 'error'});
       io.onClientMessage(clientSocketMock, connection, {requestId: 'foobar', index: 'foo', controller: 'bar', body: ['this causes an error']});
-      should(requestStub.called).be.true();
-      should(proxy.router.execute.called).be.false();
+      should(proxy.router.execute).be.calledOnce();
       should(emitStub).be.calledOnce();
       should(emitStub.firstCall.args[1]).match({
         status: 400,


### PR DESCRIPTION
## Related issue

fix #78 

## Breaking Changes
### Change  `pluginContext.accessors.router.execute` prototype 

From: 

`execute(request, callback)`

to:

`execute({payload, connectionId, protocol, headers}, callback)`
(with the `headers` property being optional)

### Remove `pluginContext.constructors.Request` from Kuzzle Proxy

With the `router.execute` change above, protocol plugins should not need this constructor anymore.
This way, it won't be in conflict with the current `pluginContext.constructors.Request` constructor in Kuzzle Core, taking a `Request` instance as its first argument, which is impossible to do in Kuzzle Proxy.