### PR TITLE
Close client connection when no backend left

### DIFF
--- a/lib/service/Backend.js
+++ b/lib/service/Backend.js
@@ -208,7 +208,9 @@ class Backend {
     // We ensure the socket is closed to avoid weird side effects
     this.socket.close();
 
-    if (this.proxy.backendHandler.getBackend(connection.id) === null) {
+    const nextBackend = this.proxy.backendHandler.getBackend(connection.id);
+
+    if (!nextBackend || !nextBackend.active) {
       const clientConnections = this.proxy.clientConnectionStore.getAll();
 
       debug('no backend left, disconnecting clients');

--- a/lib/service/Backend.js
+++ b/lib/service/Backend.js
@@ -202,13 +202,13 @@ class Backend {
     if (this.active) {
       this.proxy.backendHandler.removeBackend(this);
     }
-    
+
     this.backendRequestStore.abortAll(new KuzzleInternalError(`Connection with backend ${this.socketIp} closed.`));
 
     // We ensure the socket is closed to avoid weird side effects
     this.socket.close();
 
-    if (this.proxy.backendHandler.getBackend() === null) {
+    if (this.proxy.backendHandler.getBackend(connection.id) === null) {
       const clientConnections = this.proxy.clientConnectionStore.getAll();
 
       debug('no backend left, disconnecting clients');

--- a/lib/service/Backend.js
+++ b/lib/service/Backend.js
@@ -183,6 +183,19 @@ class Backend {
 
     // We ensure the socket is closed to avoid weird side effects
     this.socket.close();
+
+    if (this.proxy.backendHandler.getBackend() === null) {
+      const clientConnections = this.proxy.clientConnectionStore.getAll();
+
+      debug('no backend left, disconnecting clients');
+
+      for (const connection of clientConnections) {
+        const protocol = this.proxy.protocolStore.get(connection.protocol);
+        if (protocol) {
+          protocol.disconnect(connection.id);
+        }
+      }
+    }
   }
 
   /**

--- a/lib/service/Backend.js
+++ b/lib/service/Backend.js
@@ -208,7 +208,7 @@ class Backend {
     // We ensure the socket is closed to avoid weird side effects
     this.socket.close();
 
-    const nextBackend = this.proxy.backendHandler.getBackend(connection.id);
+    const nextBackend = this.proxy.backendHandler.getBackend();
 
     if (!nextBackend || !nextBackend.active) {
       const clientConnections = this.proxy.clientConnectionStore.getAll();

--- a/lib/service/Broker.js
+++ b/lib/service/Broker.js
@@ -200,7 +200,7 @@ class Broker {
   brokerCallback(room, id, connectionId, data, callback) {
     const backend = this.proxy.backendHandler.getBackend(connectionId);
 
-    if (!backend) {
+    if (!backend || !backend.active) {
       const error = new ServiceUnavailableError('Client connection refused: no Kuzzle instance found');
 
       if (process.env.NODE_ENV !== 'development') {

--- a/lib/service/Broker.js
+++ b/lib/service/Broker.js
@@ -207,15 +207,11 @@ class Broker {
     const backend = this.proxy.backendHandler.getBackend();
 
     if (!backend) {
-      const errorMessage = 'No Kuzzle instance found';
-      const error = new ServiceUnavailableError(errorMessage);
-
-      this.proxy.log.error(errorMessage, error.stack);
+      const error = new ServiceUnavailableError('Client connection refused: no Kuzzle instance found');
 
       if (process.env.NODE_ENV !== 'development') {
         delete error.stack;
       }
-
 
       callback(error);
     }

--- a/lib/service/Broker.js
+++ b/lib/service/Broker.js
@@ -184,7 +184,7 @@ class Broker {
    * @param {Error} error
    */
   onError(error) {
-    this.proxy.log.error('An error occurred with the broker socket, shutting down; Reason:\n%s', error.stack);
+    this.proxy.log.error('An error occurred with the broker socket, shutting down; Reason "%s":\n%s', error.message, error.stack);
     process.exit(1);
   }
 
@@ -202,6 +202,8 @@ class Broker {
 
     if (!backend || !backend.active) {
       const error = new ServiceUnavailableError('Client connection refused: no Kuzzle instance found');
+
+      this.proxy.log.warn(error.message);
 
       if (process.env.NODE_ENV !== 'development') {
         delete error.stack;

--- a/lib/service/protocol/SocketIo.js
+++ b/lib/service/protocol/SocketIo.js
@@ -76,7 +76,7 @@ class SocketIo {
       this.proxy.router.newConnection(connection);
     }
     catch (err) {
-      this.proxy.log.error('[socketio] Client connection refused with message "%s": initialization still underway', err.message);
+      this.proxy.log.warn('[socketio] Client connection refused with message "%s": initialization still underway', err.message);
 
       socket.emit('kuzzle_proxy_disconnection', err);
       socket.disconnect();

--- a/lib/service/protocol/SocketIo.js
+++ b/lib/service/protocol/SocketIo.js
@@ -77,8 +77,12 @@ class SocketIo {
       this.proxy.router.newConnection(connection);
     }
     catch (err) {
-      this.proxy.log.error('[socketio] Unable to register connection to the proxy\n%s', err.stack);
-      return socket.disconnect();
+      this.proxy.log.error('[socketio] Client connection refused with message "%s": initialization still underway', err.message);
+
+      socket.emit('kuzzle_proxy_disconnection', err);
+      socket.disconnect();
+
+      return false;
     }
 
     this.sockets[connection.id] = socket;
@@ -97,6 +101,8 @@ class SocketIo {
       debug('[%s] receiving a `kuzzle` event', connection.id);
       this.onClientMessage(socket, connection.id, data);
     });
+
+    return true;
   }
 
   onClientDisconnection(clientId) {
@@ -177,10 +183,11 @@ class SocketIo {
     }
   }
 
-  disconnect(connectionId) {
+  disconnect(connectionId, message = 'Connection closed by remote host') {
     debug('[%s] disconnect', connectionId);
     
     if (this.sockets[connectionId]) {
+      this.sockets[connectionId].emit('kuzzle_proxy_disconnection', new Error(message));
       this.sockets[connectionId].disconnect();
     }
   }

--- a/lib/service/protocol/SocketIo.js
+++ b/lib/service/protocol/SocketIo.js
@@ -78,7 +78,6 @@ class SocketIo {
     catch (err) {
       this.proxy.log.warn('[socketio] Client connection refused with message "%s": initialization still underway', err.message);
 
-      socket.emit('kuzzle_socketio_disconnect', err);
       socket.disconnect();
 
       return false;
@@ -180,11 +179,10 @@ class SocketIo {
     }
   }
 
-  disconnect(connectionId, message = 'Connection closed by remote host') {
+  disconnect(connectionId) {
     debug('[%s] disconnect', connectionId);
 
     if (this.sockets[connectionId]) {
-      this.sockets[connectionId].emit('kuzzle_socketio_disconnect', new Error(message));
       this.sockets[connectionId].disconnect();
     }
   }

--- a/lib/service/protocol/SocketIo.js
+++ b/lib/service/protocol/SocketIo.js
@@ -78,7 +78,7 @@ class SocketIo {
     catch (err) {
       this.proxy.log.warn('[socketio] Client connection refused with message "%s": initialization still underway', err.message);
 
-      socket.emit('kuzzle_proxy_disconnection', err);
+      socket.emit('kuzzle_socketio_disconnect', err);
       socket.disconnect();
 
       return false;
@@ -184,7 +184,7 @@ class SocketIo {
     debug('[%s] disconnect', connectionId);
 
     if (this.sockets[connectionId]) {
-      this.sockets[connectionId].emit('kuzzle_proxy_disconnection', new Error(message));
+      this.sockets[connectionId].emit('kuzzle_socketio_disconnect', new Error(message));
       this.sockets[connectionId].disconnect();
     }
   }

--- a/lib/service/protocol/Websocket.js
+++ b/lib/service/protocol/Websocket.js
@@ -64,6 +64,11 @@ class Websocket {
   }
 
   onConnection(clientSocket) {
+    if (clientSocket.upgradeReq && clientSocket.upgradeReq.url.startsWith('/socket.io/')) {
+      // Discarding request management here: let socket.io protocol manage this connection
+      return false;
+    }
+
     let ips = [clientSocket.upgradeReq.connection.remoteAddress];
     if (clientSocket.upgradeReq.headers['x-forwarded-for']) {
       ips = clientSocket.upgradeReq.headers['x-forwarded-for']
@@ -79,11 +84,12 @@ class Websocket {
       this.proxy.router.newConnection(connection);
     }
     catch (err) {
-      this.proxy.log.error('[websocket] Unable to register connection to the proxy\n%s', err.stack);
+      this.proxy.log.error('[websocket] Client connection refused with message "%s": initialization still underway', err.message);
       // Using the 4xxx code range, as the current implementation of
       // the "ws" library does not support the 1013 (Try Again Later)
       // error event
-      return clientSocket.close(4000 + err.status, err.message);
+      clientSocket.close(4000 + err.status, err.message);
+      return false;
     }
 
     this.connectionPool[connection.id] = {
@@ -106,6 +112,8 @@ class Websocket {
       debug('[%s] receiving a `message` event', connection.id);
       this.onClientMessage(connection.id, data);
     });
+
+    return true;
   }
 
   onClientDisconnection(clientId) {
@@ -255,11 +263,11 @@ class Websocket {
     }
   }
 
-  disconnect(clientId) {
+  disconnect(clientId, message = 'Connection closed by remote host') {
     debug('[%s] disconnect', clientId);
 
     if (this.connectionPool[clientId]) {
-      this.connectionPool[clientId].socket.close('CLOSEDONREQUEST', 'Connection closed by remote host');
+      this.connectionPool[clientId].socket.close(1011, message);
     }
   }
 }

--- a/lib/service/protocol/Websocket.js
+++ b/lib/service/protocol/Websocket.js
@@ -59,7 +59,7 @@ class Websocket {
   }
 
   onServerError(error) {
-    this.proxy.log.error('[websocket] An error has occured "' + error.message + '":\n' + error.stack);
+    this.proxy.log.error(`[websocket] An error has occured "${error.message}":\n${error.stack}`);
   }
 
   onConnection(clientSocket, req) {

--- a/lib/service/protocol/Websocket.js
+++ b/lib/service/protocol/Websocket.js
@@ -59,7 +59,7 @@ class Websocket {
   }
 
   onServerError(error) {
-    this.proxy.log.error('[websocket] An error has occured:\n' + error.stack);
+    this.proxy.log.error('[websocket] An error has occured "' + error.message + '":\n' + error.stack);
   }
 
   onConnection(clientSocket, req) {
@@ -83,11 +83,8 @@ class Websocket {
       this.proxy.router.newConnection(connection);
     }
     catch (err) {
-      this.proxy.log.error('[websocket] Client connection refused with message "%s": initialization still underway', err.message);
-      // Using the 4xxx code range, as the current implementation of
-      // the "ws" library does not support the 1013 (Try Again Later)
-      // error event
-      clientSocket.close(4000 + err.status, err.message);
+      this.proxy.log.warn('[websocket] Client connection refused with message "%s": initialization still underway', err.message);
+      clientSocket.close(1013, err.message);
       return false;
     }
 

--- a/test/service/backend.test.js
+++ b/test/service/backend.test.js
@@ -149,7 +149,7 @@ describe('service/Backend', () => {
     it('should remove the backend and abort all pending requests', () => {
       backend.active = true;
       backend.backendRequestStore.abortAll = sinon.spy();
-      proxy.backendHandler.getBackend.returns(['a_backend']);
+      proxy.backendHandler.getBackend.returns({socketIp: 'a_backend', active: true});
 
       backend.onConnectionClose();
 
@@ -454,5 +454,3 @@ describe('service/Backend', () => {
   });
 
 });
-
-

--- a/test/service/broker.test.js
+++ b/test/service/broker.test.js
@@ -287,9 +287,11 @@ describe('service/broker', () => {
     it('should send the request to the backend', () => {
       const
         backend = {
+          active: true,
           send: sinon.stub().yields()
         },
         cb = sinon.spy();
+
       proxy.backendHandler.getBackend.returns(backend);
 
       broker.brokerCallback('room', 'id', 'connectionId', 'data', cb);

--- a/test/service/broker.test.js
+++ b/test/service/broker.test.js
@@ -28,6 +28,7 @@ describe('service/broker', () => {
       },
       log: {
         error: sinon.spy(),
+        warn: sinon.spy(),
         info: sinon.spy()
       },
       logAccess: sinon.spy()
@@ -264,7 +265,7 @@ describe('service/broker', () => {
         broker.onError(error);
         should(proxy.log.error)
           .be.calledOnce()
-          .be.calledWith('An error occurred with the broker socket, shutting down; Reason:\n%s', error.stack);
+          .be.calledWith('An error occurred with the broker socket, shutting down; Reason "%s":\n%s', error.message, error.stack);
 
         should(Broker.__get__('process').exit)
           .be.calledOnce()

--- a/test/service/protocol/socketIo.test.js
+++ b/test/service/protocol/socketIo.test.js
@@ -365,7 +365,7 @@ describe('/service/protocol/SocketIo', function () {
       io.init(proxy);
     });
 
-    it('should send close command to force the client to close his socket', () => {
+    it('should send close notification to client and close his socket', () => {
       io.sockets.connectionId = {
         emit: sinon.spy(),
         disconnect: sinon.spy()

--- a/test/service/protocol/socketIo.test.js
+++ b/test/service/protocol/socketIo.test.js
@@ -162,13 +162,6 @@ describe('/service/protocol/SocketIo', function () {
 
       should(onClientSpy.callCount).be.eql(0);
 
-      should(clientSocketMock.emit)
-        .be.calledOnce();
-
-      should(clientSocketMock.emit.getCall(0).args[0]).be.eql('kuzzle_socketio_disconnect');
-      should(clientSocketMock.emit.getCall(0).args[1]).be.instanceof(Error);
-      should(clientSocketMock.emit.getCall(0).args[1].message).be.eql('test');
-
       should(clientSocketMock.disconnect)
         .be.calledOnce();
     });
@@ -368,15 +361,10 @@ describe('/service/protocol/SocketIo', function () {
 
     it('should send close notification to client and close his socket', () => {
       io.sockets.connectionId = {
-        emit: sinon.spy(),
         disconnect: sinon.spy()
       };
 
       io.disconnect('connectionId', 'nope');
-
-      should(io.sockets.connectionId.emit.getCall(0).args[0]).be.eql('kuzzle_socketio_disconnect');
-      should(io.sockets.connectionId.emit.getCall(0).args[1]).be.instanceof(Error);
-      should(io.sockets.connectionId.emit.getCall(0).args[1].message).be.eql('nope');
 
       should(io.sockets.connectionId.disconnect)
         .be.calledOnce();

--- a/test/service/protocol/socketIo.test.js
+++ b/test/service/protocol/socketIo.test.js
@@ -89,7 +89,8 @@ describe('/service/protocol/SocketIo', function () {
         }
       },
       log: {
-        error: sinon.spy()
+        error: sinon.spy(),
+        warn: sinon.spy()
       },
       logAccess: sinon.spy()
     };
@@ -164,7 +165,7 @@ describe('/service/protocol/SocketIo', function () {
       should(clientSocketMock.emit)
         .be.calledOnce();
 
-      should(clientSocketMock.emit.getCall(0).args[0]).be.eql('kuzzle_proxy_disconnection');
+      should(clientSocketMock.emit.getCall(0).args[0]).be.eql('kuzzle_socketio_disconnect');
       should(clientSocketMock.emit.getCall(0).args[1]).be.instanceof(Error);
       should(clientSocketMock.emit.getCall(0).args[1].message).be.eql('test');
 
@@ -373,7 +374,7 @@ describe('/service/protocol/SocketIo', function () {
 
       io.disconnect('connectionId', 'nope');
 
-      should(io.sockets.connectionId.emit.getCall(0).args[0]).be.eql('kuzzle_proxy_disconnection');
+      should(io.sockets.connectionId.emit.getCall(0).args[0]).be.eql('kuzzle_socketio_disconnect');
       should(io.sockets.connectionId.emit.getCall(0).args[1]).be.instanceof(Error);
       should(io.sockets.connectionId.emit.getCall(0).args[1].message).be.eql('nope');
 

--- a/test/service/protocol/websocket.test.js
+++ b/test/service/protocol/websocket.test.js
@@ -92,6 +92,7 @@ describe('/service/protocol/Websocket', function () {
           connection: {
             remoteAddress: 'ip'
           },
+          url: '/',
           headers: {
             'X-Foo': 'bar',
             'x-forwarded-for': '1.1.1.1,2.2.2.2'
@@ -153,12 +154,17 @@ describe('/service/protocol/Websocket', function () {
 
       ws.onConnection(clientSocketMock);
 
-      should(proxy.log.error)
-        .be.calledWith('[websocket] Unable to register connection to the proxy\n%s', error.stack);
-
       should(onClientSpy.callCount).be.eql(0);
       should(clientSocketMock.close.called).be.true();
       should(clientSocketMock.close.calledWith(4503, 'foobar'));
+
+    });
+
+    it('should do nothing if message is for socket.io', () => {
+      clientSocketMock.upgradeReq.url = '/socket.io/roomid';
+
+      should(ws.onConnection(clientSocketMock))
+        .be.false();
 
     });
   });
@@ -604,11 +610,11 @@ describe('/service/protocol/Websocket', function () {
         }
       };
 
-      ws.disconnect('id');
+      ws.disconnect('id', 'nope');
 
       should(ws.connectionPool.id.socket.close)
         .be.calledOnce()
-        .be.calledWith('CLOSEDONREQUEST', 'Connection closed by remote host');
+        .be.calledWith(1011, 'nope');
     });
 
   });

--- a/test/service/protocol/websocket.test.js
+++ b/test/service/protocol/websocket.test.js
@@ -58,7 +58,8 @@ describe('/service/protocol/Websocket', function () {
         }
       },
       log: {
-        error: sinon.spy()
+        error: sinon.spy(),
+        warn: sinon.spy()
       },
       logAccess: sinon.spy()
     };
@@ -519,7 +520,7 @@ describe('/service/protocol/Websocket', function () {
 
       should(proxy.log.error)
         .be.calledOnce()
-        .be.calledWith('[websocket] An error has occured:\n' + error.stack);
+        .be.calledWith(`[websocket] An error has occured "${error.message}":\n${error.stack}`);
     });
   });
 

--- a/test/service/protocol/websocket.test.js
+++ b/test/service/protocol/websocket.test.js
@@ -151,9 +151,6 @@ describe('/service/protocol/Websocket', function () {
 
       ws.onConnection(clientSocketMock, req);
 
-      should(proxy.log.error)
-        .be.calledWith('[websocket] Unable to register connection to the proxy\n%s', error.stack);
-
       should(onClientSpy.callCount).be.eql(0);
       should(clientSocketMock.close.called).be.true();
       should(clientSocketMock.close.calledWith(4503, 'foobar'));
@@ -161,9 +158,9 @@ describe('/service/protocol/Websocket', function () {
     });
 
     it('should do nothing if message is for socket.io', () => {
-      clientSocketMock.upgradeReq.url = '/socket.io/roomid';
+      req.url = '/socket.io/roomid';
 
-      should(ws.onConnection(clientSocketMock))
+      should(ws.onConnection(clientSocketMock, req))
         .be.false();
 
     });

--- a/test/service/router.test.js
+++ b/test/service/router.test.js
@@ -29,7 +29,7 @@ describe('#Test: service/Router', function () {
   beforeEach(() => {
     proxy = {
       backendHandler: {
-        getBackend: sinon.stub().returns({})
+        getBackend: sinon.stub().returns({active: true})
       },
       broker: {
         addClientConnection: sinon.spy(),
@@ -58,6 +58,13 @@ describe('#Test: service/Router', function () {
   describe('#newConnection', () => {
     it('should throw if no backend is available', () => {
       proxy.backendHandler.getBackend.returns(undefined);
+
+      return should(() => router.newConnection({}))
+        .throw(ServiceUnavailableError, {message: 'No Kuzzle instance found'});
+    });
+
+    it('should throw if no backend is active', () => {
+      proxy.backendHandler.getBackend.returns({active: false});
 
       return should(() => router.newConnection({}))
         .throw(ServiceUnavailableError, {message: 'No Kuzzle instance found'});


### PR DESCRIPTION
## Changes
- When no backend are left, disconnect active client connection with error message
- When no backend are left and a new connection is established, refuse it

## Bugfixes
- Websocket request from Socket.IO were also managed by Websocket protocol 
- Removed useless logs in proxy output